### PR TITLE
Limit number of delegates fetched

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -37,3 +37,4 @@ export const APP_TIMEOUT_DESTROY = 60000;
 // ARK
 export const PRIVACY_POLICY_URL = 'https://ark.io/PrivacyPolicy.txt';
 export const URI_QRCODE_SCHEME_PREFIX = "ark:";
+export const NUM_ACTIVE_DELEGATES = 51;

--- a/src/pages/delegates/delegates.ts
+++ b/src/pages/delegates/delegates.ts
@@ -162,19 +162,19 @@ export class DelegatesPage {
   ionViewDidEnter() {
     this.currentNetwork = this.arkApiProvider.network;
     this.currentWallet = this.userDataProvider.currentWallet;
-
+    const NUM_ACTIVE_DELEGATES = 51
     this.zone.runOutsideAngular(() => {
       this.arkApiProvider.delegates.subscribe((data) => this.zone.run(() => {
         this.delegates = data;
-        this.activeDelegates = this.delegates.slice(0, 51);
-        this.standByDelegates = this.delegates.slice(51, this.delegates.length);
+        this.activeDelegates = this.delegates.slice(0, NUM_ACTIVE_DELEGATES);
+        this.standByDelegates = this.delegates.slice(NUM_ACTIVE_DELEGATES, this.delegates.length);
       }));
     })
 
     this.onUpdateDelegates();
     // this.getSupply();
     this.fetchCurrentVote();
-    this.arkApiProvider.fetchAllDelegates().subscribe();
+    this.arkApiProvider.fetchDelegates(false, NUM_ACTIVE_DELEGATES*2).subscribe();
 
     // this.refreshListener = setInterval(() => this.getSupply(), constants.WALLET_REFRESH_TRANSACTIONS_MILLISECONDS);
   }

--- a/src/pages/delegates/delegates.ts
+++ b/src/pages/delegates/delegates.ts
@@ -162,19 +162,18 @@ export class DelegatesPage {
   ionViewDidEnter() {
     this.currentNetwork = this.arkApiProvider.network;
     this.currentWallet = this.userDataProvider.currentWallet;
-    const NUM_ACTIVE_DELEGATES = 51
     this.zone.runOutsideAngular(() => {
       this.arkApiProvider.delegates.subscribe((data) => this.zone.run(() => {
         this.delegates = data;
-        this.activeDelegates = this.delegates.slice(0, NUM_ACTIVE_DELEGATES);
-        this.standByDelegates = this.delegates.slice(NUM_ACTIVE_DELEGATES, this.delegates.length);
+        this.activeDelegates = this.delegates.slice(0, constants.NUM_ACTIVE_DELEGATES);
+        this.standByDelegates = this.delegates.slice(constants.NUM_ACTIVE_DELEGATES, this.delegates.length);
       }));
     })
 
     this.onUpdateDelegates();
     // this.getSupply();
     this.fetchCurrentVote();
-    this.arkApiProvider.fetchDelegates(false, NUM_ACTIVE_DELEGATES*2).subscribe();
+    this.arkApiProvider.fetchDelegates(constants.NUM_ACTIVE_DELEGATES*2).subscribe();
 
     // this.refreshListener = setInterval(() => this.getSupply(), constants.WALLET_REFRESH_TRANSACTIONS_MILLISECONDS);
   }

--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -72,7 +72,7 @@ export class ArkApiProvider {
   public get delegates(): Observable<arkts.Delegate[]> {
     if (!lodash.isEmpty(this._delegates)) return Observable.of(this._delegates);
 
-    return this.fetchAllDelegates();
+    return this.fetchDelegates(false, 102);
   }
 
   public findGoodPeer(): void {
@@ -100,7 +100,7 @@ export class ArkApiProvider {
     });
   }
 
-  public fetchAllDelegates(): Observable<arkts.Delegate[]> {
+  public fetchDelegates(getAllDelegates: boolean, numberDelegatesToGet: number): Observable<arkts.Delegate[]> {
     if (!this._api) return;
     const limit = 51;
 
@@ -119,9 +119,8 @@ export class ArkApiProvider {
         return currentPage < totalPages ? req : Observable.empty();
       }).do((response) => {
         offset += limit;
-        if (response.success) totalCount = response.totalCount;
-        totalPages = Math.ceil(totalCount / limit);
-
+        if (response.success && getAllDelegates) numberDelegatesToGet = response.totalCount;
+        totalPages = Math.ceil(numberDelegatesToGet / limit);
         currentPage++;
       }).finally(() => {
         this.storageProvider.set(constants.STORAGE_DELEGATES, delegates);
@@ -227,7 +226,7 @@ export class ArkApiProvider {
     this.userDataProvider.updateNetwork(this.userDataProvider.currentProfile.networkId, this._network);
     this._api = new arkts.Client(this._network);
 
-    this.fetchAllDelegates().subscribe((data) => {
+    this.fetchDelegates(false, 102).subscribe((data) => {
       this._delegates = data;
     });
 

--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -72,7 +72,7 @@ export class ArkApiProvider {
   public get delegates(): Observable<arkts.Delegate[]> {
     if (!lodash.isEmpty(this._delegates)) return Observable.of(this._delegates);
 
-    return this.fetchDelegates(false, 102);
+    return this.fetchDelegates(constants.NUM_ACTIVE_DELEGATES*2);
   }
 
   public findGoodPeer(): void {
@@ -100,7 +100,7 @@ export class ArkApiProvider {
     });
   }
 
-  public fetchDelegates(getAllDelegates: boolean, numberDelegatesToGet: number): Observable<arkts.Delegate[]> {
+  public fetchDelegates(numberDelegatesToGet: number, getAllDelegates = false): Observable<arkts.Delegate[]> {
     if (!this._api) return;
     const limit = 51;
 
@@ -226,7 +226,7 @@ export class ArkApiProvider {
     this.userDataProvider.updateNetwork(this.userDataProvider.currentProfile.networkId, this._network);
     this._api = new arkts.Client(this._network);
 
-    this.fetchDelegates(false, 102).subscribe((data) => {
+    this.fetchDelegates(constants.NUM_ACTIVE_DELEGATES*2).subscribe((data) => {
       this._delegates = data;
     });
 


### PR DESCRIPTION
Zillion made a good point (#8), we should limit the number of delegates that need to be gotten/loaded, since plenty of the standby delegates aren't close to being active.

Generalized fetchAllDelegates to fetchDelegates which takes in two parameters.

First is a boolean which is called getAllDelegates if true -> will get all the delegates.
Second is the number of delegates you want, if getAllDelegates is false then we use this to get the totalPages. 

Did this instead of having two methods, fetchDelegates and fetchAllDelegates, seemed cleaner. 

For the pr I have every fetchDelegates call set to false and 102, so 51 active delegates + next 51 for standby.

Open to suggestions!