### PR TITLE
Fixes more options for a transaction

### DIFF
--- a/src/pages/transaction/transaction-show/transaction-show.ts
+++ b/src/pages/transaction/transaction-show/transaction-show.ts
@@ -60,7 +60,7 @@ export class TransactionShowPage {
     let address = this.transaction.getAppropriateAddress();
     let addressTruncated = this.TruncateMiddlePipe.transform(address, 10, null);
     let contact = this.userDataProvider.getContactByAddress(address);
-    let contactOrAddress = contact['name'] || addressTruncated;
+    let contactOrAddress = contact ? contact['name'] : addressTruncated;
 
     this.translateService.get([
       'TRANSACTIONS_PAGE.ADD_ADDRESS_TO_CONTACTS',


### PR DESCRIPTION
Noticed that if you went to you wallet -> clicked on a transaction -> clicked top right for more options it'd break since it contact could be undefined. 

Fixed now! So when you click on it it'll show Add x to contacts, and send ark to y address.