### PR TITLE
Add word validation when generating passphrase

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -91,6 +91,10 @@
   },
   "NEXT": "Next",
   "NO": "No",
+  "PASSPHRASE_TEST": {
+    "INFO": "Please type the required words from your passphrase to validate the wallet creation.",
+    "WRONG_WORD": "The typed word is not correct"
+  },
   "PIN_CODE": {
     "CONFIRM": "Confirm your PIN",
     "CREATE": "Create your PIN",
@@ -235,5 +239,6 @@
     "TUESDAY": "Tue",
     "WEDNESDAY": "Wed"
   },
+  "WORD": "Word",
   "YES": "Yes"
 }

--- a/src/directives/mainnet-only/mainnet-only.ts
+++ b/src/directives/mainnet-only/mainnet-only.ts
@@ -1,6 +1,5 @@
 import { Directive, ElementRef, OnInit } from '@angular/core';
 import { UserDataProvider } from '@providers/user-data/user-data';
-import { NetworkType } from 'ark-ts/model';
 
 @Directive({
   selector: '[appMainnetOnly]'
@@ -12,7 +11,7 @@ export class MainnetOnlyDirective implements OnInit {
   ) { }
 
   ngOnInit() {
-    if (this.userDataProvider.currentNetwork && this.userDataProvider.currentNetwork.type === NetworkType.Devnet) {
+    if (this.userDataProvider.isDevNet) {
       this.elementRef.nativeElement.style.display = 'none';
     }
   }

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.html
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.html
@@ -1,0 +1,53 @@
+<ion-header>
+
+  <ion-navbar no-border class="dark-navbar">
+    <h6 class="no-padding no-margin" text-center>{{ 'WALLETS_PAGE.CREATE_WALLET' | translate }}</h6>
+
+    <ion-buttons end>
+      <button ion-button icon-only (click)="dismiss()">
+        <ion-icon name="close" color="light"></ion-icon>
+      </button>
+    </ion-buttons>
+  </ion-navbar>
+
+</ion-header>
+
+<ion-content no-bounce>
+  <ion-grid padding class="dark-navbar">
+    <ion-row>
+      <ion-col text-center>
+        <p class="sole-message">{{ 'PASSPHRASE_TEST.INFO' | translate }}</p>
+      </ion-col>
+    </ion-row>
+    <ion-row class="account-container">
+      <ion-col>
+          <form #wordsForm="ngForm">
+            <ng-container *ngFor="let word of words">
+              <ion-item>
+                <ion-label floating>{{ 'WORD' | translate }} {{word.number}}</ion-label>
+                <ion-input type="text"
+                           [name]="'word_' + word.number"
+                           [(ngModel)]="word.userValue"
+                           (keyup)="word.isUserTyped = true"
+                           required
+                           autocapitalize="none">
+                </ion-input>
+              </ion-item>
+              <ion-item class="no-border">
+                <p class="error-message" *ngIf="word.hasUIError">{{ 'PASSPHRASE_TEST.WRONG_WORD' | translate }}</p>
+              </ion-item>
+            </ng-container>
+          </form>
+      </ion-col>
+    </ion-row>
+    <ion-row>
+      <ion-col>
+        <div text-center>
+          <button ion-button class="button-continue" (click)="next()" [disabled]="!wordsForm.valid || !areAllWordsCorrect()">
+            {{ 'NEXT' | translate }}
+          </button>
+        </div>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+</ion-content>

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.module.ts
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+
+import { TranslateModule } from '@ngx-translate/core';
+import {PassphraseWordTesterModal} from "./passphrase-word-tester";
+
+@NgModule({
+  declarations: [
+    PassphraseWordTesterModal,
+  ],
+  imports: [
+    IonicPageModule.forChild(PassphraseWordTesterModal),
+    TranslateModule
+  ],
+})
+export class PassphraseWordTesterModalModule {}

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.scss
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.scss
@@ -1,0 +1,3 @@
+.sole-message {
+  color: #000;
+}

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.ts
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.ts
@@ -1,0 +1,35 @@
+import {Component} from '@angular/core';
+import {IonicPage, NavController, NavParams, ViewController} from 'ionic-angular';
+import {PassphraseWord} from "@models/passphrase-word";
+
+@IonicPage()
+@Component({
+  selector: 'modal-passphrase-word-tester',
+  templateUrl: 'passphrase-word-tester.html',
+})
+export class PassphraseWordTesterModal {
+
+  public words: PassphraseWord[] = [];
+
+  public constructor(public navCtrl: NavController,
+              public navParams: NavParams,
+              private viewCtrl: ViewController) {
+    this.words = this.navParams.get('words') as PassphraseWord[];
+
+    if (!this.words) {
+      this.dismiss();
+    }
+  }
+
+  public areAllWordsCorrect(): boolean {
+    return this.words.every(w => w.isCorrect);
+  }
+
+  public next(): void {
+    this.dismiss(this.areAllWordsCorrect());
+  }
+
+  public dismiss(validationSuccess?: boolean): void {
+    this.viewCtrl.dismiss(validationSuccess);
+  }
+}

--- a/src/modals/wallet-backup/wallet-backup.module.ts
+++ b/src/modals/wallet-backup/wallet-backup.module.ts
@@ -7,12 +7,12 @@ import { QRCodeComponentModule } from '@components/qr-code/qr-code.module';
 
 @NgModule({
   declarations: [
-    WalletBackupModal,
+    WalletBackupModal
   ],
   imports: [
     IonicPageModule.forChild(WalletBackupModal),
     TranslateModule,
-    QRCodeComponentModule,
+    QRCodeComponentModule
   ],
 })
 export class WalletBackupModalModule {}

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -5,3 +5,4 @@ export * from './profile';
 export * from './settings';
 export * from './wallet';
 export * from './translate';
+export * from './passphrase-word';

--- a/src/models/passphrase-word.ts
+++ b/src/models/passphrase-word.ts
@@ -1,0 +1,14 @@
+export class PassphraseWord {
+  public isUserTyped: boolean;
+
+  public constructor(private passphraseValue, public number, public userValue?: string) {
+  }
+
+  public get hasUIError(): boolean {
+    return this.isUserTyped && !this.isCorrect;
+  }
+
+  public get isCorrect(): boolean {
+    return this.userValue == this.passphraseValue;
+  }
+}

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -13,6 +13,7 @@ import { v4 as uuid } from 'uuid';
 import { Network } from 'ark-ts/model';
 
 import * as constants from '@app/app.constants';
+import { NetworkType } from "ark-ts";
 
 @Injectable()
 export class UserDataProvider {
@@ -28,6 +29,10 @@ export class UserDataProvider {
   public onCreateWallet$: Subject<Wallet> = new Subject();
   public onUpdateWallet$: Subject<Wallet> = new Subject();
   public onSelectProfile$: Subject<Profile> = new Subject();
+
+  public get isDevNet(): boolean {
+    return this.currentNetwork && this.currentNetwork.type === NetworkType.Devnet;
+  }
 
   constructor(
     private storageProvider: StorageProvider,

--- a/src/utils/ark-utility.ts
+++ b/src/utils/ark-utility.ts
@@ -2,6 +2,10 @@ import * as constants from '@app/app.constants';
 import BigNumber from "bignumber.js";
 
 export class ArkUtility {
+  public static getRandomInt(min: number, max: number): number {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
+
   public static arktoshiToArk(ark: number, returnRaw: boolean = false): number {
     let result: number = ark / constants.WALLET_UNIT_TO_SATOSHI;
 


### PR DESCRIPTION
I always liked the word validation which we have in ark-desktop, so I added the same validation here.

A few notes:
- I designed the word validation so that it will also work with a different nubmer of words, or more words, etc. => we could also make it random, each time a passphrase is generated (so the user cannot simply remember the 3, 6 and 9 word)
- I added a little gimmick, that when we are on `devnet` the words area already prefilled, so we can go faster in testing (for this purpose I added a gett er `isTestNet` to the `UserDataProvider` so we could also use this feature elsewhere (if you approve it of course ;) )

By the way if you omitted this feature on purpose on mobile, you can of course decline the PR, I really just wanted to play a little with cordova and get into it and find this a cool feature :)

Also: How do we handle translations? I'm not fluent in swedish (=I do not speak a single word of it), so I omitted it.

Tested on:
 - Browser
- Android

![screenshot_20171231-112647](https://user-images.githubusercontent.com/1086065/34460966-53bc7cc8-ee1e-11e7-84c5-7bf7fd76148c.jpg)

