### PR TITLE
Fix address/contacts bug in send-transaction & more

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,6 +1,8 @@
 {
   "API": {
     "BALANCE_TOO_LOW": "Balance too low for transaction",
+    "BALANCE_TOO_LOW_DETAIL": "Not enough {{ token }} on your account! The transaction costs are: {{ totalAmount }} ({{ amount }} + {{ fee }} fee). However your account balance is only {{ balance }}!",
+    "DESTINATION_ADDRESS_ERROR": "The destination address {{ address }} is erroneous",
     "PEER_LIST_ERROR": "Could not get list of peers",
     "TRANSACTION_FAILED": "Transaction failed",
     "TRANSACTION_SENT": "Transaction was sent"

--- a/src/components/confirm-transaction/confirm-transaction.ts
+++ b/src/components/confirm-transaction/confirm-transaction.ts
@@ -1,7 +1,8 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { ArkApiProvider } from '@providers/ark-api/ark-api';
 import { ModalController, NavController } from 'ionic-angular';
-import { Wallet, WalletKeys, Transaction } from '@models/model';
+import { Wallet, WalletKeys, Transaction, TranslatableObject } from '@models/model';
+import { TranslateService } from "@ngx-translate/core";
 
 import lodash from 'lodash';
 
@@ -20,6 +21,7 @@ export class ConfirmTransactionComponent {
     private arkApiProvider: ArkApiProvider,
     private modalCtrl: ModalController,
     private navCtrl: NavController,
+    private translateService: TranslateService
   ) { }
 
   open(transaction: any, keys: WalletKeys) {
@@ -51,12 +53,15 @@ export class ConfirmTransactionComponent {
         });
 
         modal.present();
-      }, (error) => {
-        this.onError.emit(error);
-        this.presentWrongModal({
-          status: false,
-          message: error
-        })
+      }, (error: TranslatableObject) => {
+        this.translateService.get(error.key, error.parameters)
+          .subscribe((errorMessage) => {
+            this.onError.emit(errorMessage);
+            this.presentWrongModal({
+              status: false,
+              message: errorMessage
+            });
+          });
       });
   }
 

--- a/src/modals/confirm-transaction/confirm-transaction.html
+++ b/src/modals/confirm-transaction/confirm-transaction.html
@@ -13,14 +13,22 @@
           <ion-item no-lines text-wrap>
             <ion-label stacked>
               <p>{{ 'TRANSACTIONS_PAGE.FROM' | translate }}</p>
-              <h6 ion-content>{{ address }}</h6>
+              <h6 ion-content>{{ address | accountLabel }}
+                <span *ngIf="(address | accountLabel) != address">
+                  {{address}}
+                </span>
+              </h6>
             </ion-label>
           </ion-item>
 
           <ion-item no-lines text-wrap *ngIf="transaction?.type == 0">
             <ion-label stacked>
               <p>{{ 'TRANSACTIONS_PAGE.RECIPIENT' | translate }}</p>
-              <h6 ion-content>{{ transaction?.recipientId }}</h6>
+              <h6 ion-content>{{ transaction?.recipientId | accountLabel }}
+                <span *ngIf="(transaction?.recipientId  | accountLabel) != transaction?.recipientId">
+                  {{transaction?.recipientId}}
+                </span>
+              </h6>
             </ion-label>
           </ion-item>
 

--- a/src/modals/confirm-transaction/confirm-transaction.scss
+++ b/src/modals/confirm-transaction/confirm-transaction.scss
@@ -27,4 +27,11 @@ modal-confirm-transaction {
       margin-top: 1rem!important;
     }
   }
+
+  h6 {
+    span {
+      display: block;
+      font-size: .75em
+    }
+  }
 }

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -5,6 +5,12 @@ export interface AddressMap {
   highlight?: boolean;
 }
 
+export interface AutoCompleteContact {
+  address: string;
+  name: string;
+  iconName: string;
+}
+
 export class Contact {
   name: string;
   description?: string;

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -4,3 +4,4 @@ export * from './transaction';
 export * from './profile';
 export * from './settings';
 export * from './wallet';
+export * from './translate';

--- a/src/models/translate.ts
+++ b/src/models/translate.ts
@@ -1,0 +1,4 @@
+export interface TranslatableObject {
+  key: string;
+  parameters?: Object;
+}

--- a/src/pages/contacts/contact-create/contact-create.ts
+++ b/src/pages/contacts/contact-create/contact-create.ts
@@ -9,6 +9,7 @@ import { PublicKey } from 'ark-ts/core';
 import { QRScannerComponent } from '@components/qr-scanner/qr-scanner';
 
 import lodash from 'lodash';
+import { ToastProvider } from "@providers/toast/toast";
 
 @IonicPage()
 @Component({
@@ -30,7 +31,8 @@ export class ContactCreatePage {
   constructor(
     private navCtrl: NavController,
     private navParams: NavParams,
-    private userDataProvider: UserDataProvider
+    private userDataProvider: UserDataProvider,
+    private toastProvider: ToastProvider
   ) {
     let param = this.navParams.get('contact');
     this.address = this.navParams.get('address');
@@ -43,7 +45,7 @@ export class ContactCreatePage {
 
   validateAddress() {
     let validate = PublicKey.validateAddress(this.address, this.currentNetwork);
-    this.createContactForm.form.controls['address'].setErrors({ incorret: !validate });
+    this.createContactForm.form.controls['address'].setErrors({ incorrect: !validate });
     if (validate) this.createContactForm.form.controls['address'].setErrors(null);
 
     return validate;

--- a/src/pages/transaction/transaction-send/transaction-send.html
+++ b/src/pages/transaction/transaction-send/transaction-send.html
@@ -16,18 +16,41 @@
         <ion-col>
           <ion-item>
             <ion-label stacked>{{ 'WALLETS_PAGE.ADDRESS' | translate }}</ion-label>
-            <ion-auto-complete item-content [dataProvider]="contactsAutoCompleteService" [showResultsFirst]="true" [options]="{placeholder: ''}" formControlName="recipientAddress" (itemSelected)="onSearchItem($event)" (ionAutoInput)="onSearchInput($event)" #searchBar></ion-auto-complete>
+            <ng-template #contactsTemplate let-attrs="attrs">
+              <span class="auto-complete-row">
+                <ion-icon [name]="attrs.data.iconName" item-start></ion-icon>
+                <span>
+                  <span [innerHTML]="attrs.data.name | boldprefix:attrs.keyword"></span>
+                  <span class="autocomplete-second-line" [innerHTML]="attrs.data.address | boldprefix:attrs.keyword"></span>
+                </span>
+                </span>
+            </ng-template>
+            <ion-auto-complete item-content
+                               [dataProvider]="contactsAutoCompleteService"
+                               [showResultsFirst]="true"
+                               [options]="{placeholder: ''}"
+                               formControlName="recipientAddress"
+                               (itemSelected)="onSearchItem($event)"
+                               (ionAutoInput)="onSearchInput($event)"
+                               [template]="contactsTemplate"
+                               #searchBar>
+            </ion-auto-complete>
             <div class="qr-container" item-right>
               <img src="./assets/img/light/wallet/qr-code-button.png" tappable (tap)="scanQRCode()" />
             </div>
           </ion-item>
         </ion-col>
       </ion-row>
-      <ion-row *ngIf="!contact">
+      <ion-row *ngIf="!isExistingContact">
         <ion-col>
           <ion-item>
             <ion-label stacked>{{ 'TRANSACTIONS_PAGE.CONTACT_NAME' | translate }}</ion-label>
-            <ion-input type="text" formControlName="recipientName" name="recipientName" [(ngModel)]="transaction.recipientName"></ion-input>
+            <ion-input type="text"
+                       formControlName="recipientName"
+                       name="recipientName"
+                       [(ngModel)]="transaction.recipientName"
+                       (keyup)="isRecipientNameAutoSet = false">
+            </ion-input>
           </ion-item>
         </ion-col>
       </ion-row>
@@ -38,13 +61,32 @@
               <ion-col>
                 <ion-item>
                   <ion-label stacked>{{ currentNetwork?.token }}</ion-label>
-                  <ion-input type="number" formControlName="amount" step="0.00000001" min="0.00000001" max="10000000000" name="amount" [(ngModel)]="transaction.amount" (input)="onInputToken()" [placeholder]="tokenPlaceholder" required></ion-input>
+                  <ion-input type="number"
+                             formControlName="amount"
+                             step="0.00000001"
+                             min="0.00000001"
+                             max="10000000000"
+                             name="amount"
+                             [(ngModel)]="transaction.amount"
+                             (input)="onInputToken()"
+                             [placeholder]="tokenPlaceholder"
+                             required>
+                  </ion-input>
                 </ion-item>
               </ion-col>
               <ion-col appMainnetOnly>
                 <ion-item>
                   <ion-label stacked>{{ marketCurrency?.code | uppercase }}</ion-label>
-                  <ion-input type="number" formControlName="amountEquivalent" step="0.01" min="0.00000001" max="10000000000" name="amountEquivalent" [(ngModel)]="transaction.amountEquivalent" (input)="onInputFiat()" [placeholder]="fiatPlaceholder" required></ion-input>
+                  <ion-input type="number"
+                             formControlName="amountEquivalent"
+                             step="0.01" min="0.00000001"
+                             max="10000000000"
+                             name="amountEquivalent"
+                             [(ngModel)]="transaction.amountEquivalent"
+                             (input)="onInputFiat()"
+                             [placeholder]="fiatPlaceholder"
+                             required>
+                  </ion-input>
                 </ion-item>
               </ion-col>
             </ion-row>

--- a/src/pages/transaction/transaction-send/transaction-send.scss
+++ b/src/pages/transaction/transaction-send/transaction-send.scss
@@ -82,6 +82,15 @@ page-transaction-send {
       -webkit-box-shadow: inset 0 -1px 0 0 #f53d3d;
       box-shadow: inset 0 -1px 0 0 #f53d3d;
     }
+
+    .auto-complete-row {
+      display: flex;
+
+      .autocomplete-second-line {
+        display: block;
+        font-size: .75em
+      }
+    }
   }
   .item {
     padding-left: 0;

--- a/src/pipes/units-satoshi/units-satoshi.ts
+++ b/src/pipes/units-satoshi/units-satoshi.ts
@@ -1,6 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { ARKTOSHI_DP, WALLET_UNIT_TO_SATOSHI } from '@app/app.constants';
-import { BigNumber } from 'bignumber.js';
+import { ArkUtility } from "../../utils/ark-utility";
 
 @Pipe({
   name: 'unitsSatoshi',
@@ -10,12 +9,6 @@ export class UnitsSatoshiPipe implements PipeTransform {
   transform(value: number | string, returnRaw: boolean = false) {
     if (typeof value === 'string') value = Number(value);
 
-    let result: any = value / WALLET_UNIT_TO_SATOSHI;
-
-    if (!returnRaw) {
-      result = Number((new BigNumber(result.toString())).toFixed(ARKTOSHI_DP));
-    }
-
-    return result;
+    return ArkUtility.arktoshiToArk(value, returnRaw);
   }
 }

--- a/src/providers/toast/toast.ts
+++ b/src/providers/toast/toast.ts
@@ -4,6 +4,7 @@ import { ToastController } from 'ionic-angular';
 import { TranslateService } from '@ngx-translate/core';
 
 import * as constants from '@app/app.constants';
+import { TranslatableObject } from "@models/translate";
 
 @Injectable()
 export class ToastProvider {
@@ -34,32 +35,42 @@ export class ToastProvider {
     translateService.use('en');
   }
 
-  error(message: string, hideDelay?: number, position?: string): void {
+  error(message: string | TranslatableObject, hideDelay?: number, position?: string): void {
     this.show(message, this.TypeEnum.ERROR, hideDelay, position);
   }
 
-  success(message: string, hideDelay?: number, position?: string): void {
+  success(message: string | TranslatableObject, hideDelay?: number, position?: string): void {
     this.show(message, this.TypeEnum.SUCCESS, hideDelay, position);
   }
 
-  warn(message: string, hideDelay?: number, position?: string): void {
+  warn(message: string | TranslatableObject, hideDelay?: number, position?: string): void {
     this.show(message, this.TypeEnum.WARN, hideDelay, position);
   }
 
-  log(message: string, hideDelay?: number, position?: string): void {
+  log(message: string | TranslatableObject, hideDelay?: number, position?: string): void {
     this.show(message, this.TypeEnum.LOG, hideDelay, position);
   }
 
-  debug(message: string, hideDelay?: number, position?: string): void {
+  debug(message: string | TranslatableObject, hideDelay?: number, position?: string): void {
     this.show(message, this.TypeEnum.DEBUG, hideDelay, position);
   }
 
-  show(message: string, type?: number, hideDelay?: number, position?: string) {
+  show(messageOrObj: string | TranslatableObject, type?: number, hideDelay?: number, position?: string) {
     let cssClass = 'toast-service';
     if (this.TypeName[type]) {
       cssClass += ' toast-' + this.TypeName[type]
     }
-    this.translateService.get(message).subscribe((translation) => {
+    let message: string;
+    let parameters: any;
+    if (typeof messageOrObj === 'string') {
+      message = messageOrObj as string;
+      parameters = null;
+    } else {
+      const obj = messageOrObj as TranslatableObject;
+      message = obj.key;
+      parameters = obj.parameters;
+    }
+    this.translateService.get(message, parameters).subscribe((translation) => {
       let toast = this.toastCtrl.create({
         message: translation,
         duration: hideDelay || this.hideDelay,

--- a/src/utils/ark-utility.ts
+++ b/src/utils/ark-utility.ts
@@ -1,0 +1,14 @@
+import * as constants from '@app/app.constants';
+import BigNumber from "bignumber.js";
+
+export class ArkUtility {
+  public static arktoshiToArk(ark: number, returnRaw: boolean = false): number {
+    let result: number = ark / constants.WALLET_UNIT_TO_SATOSHI;
+
+    if (!returnRaw) {
+      result = Number((new BigNumber(result.toString())).toFixed(constants.ARKTOSHI_DP));
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
Noticed multiple bugs in the send transaction form concerning the contact:

- if you selected an existing contact and clicked into the same field again, the new contact field did appear
- "Contact" was hardcoded in english
- the `recipientName` was not always set

I fixed this, refactored and also changed the following:

- changed sort orer to the following:
  - all contacts (alphabetical)
  - all wallets
    - labeled wallets (alphabetical)
    - unlabled wallets (alphabetical)
- added icons for contacts and wallets and show the address to the contact / label on the second line:
   ![image](https://user-images.githubusercontent.com/1086065/34638714-ca0a6b6c-f2d1-11e7-8310-c34c1a9e8c06.png)

- searched words are highlighted within the results:
  ![image](https://user-images.githubusercontent.com/1086065/34638668-09b2d0fc-f2d1-11e7-8b95-837419edd11c.png)
- logic of when the "new contact" field appears:
  - if you type an address
  - if you scan a qr code and there is NO corresponding contact or wallet
  - if you select a wallet WITHOUT a label (for wallets with label the contact field doesn't appear)
- on confirm page show label & address:
   ![image](https://user-images.githubusercontent.com/1086065/34638873-19277476-f2d5-11e7-9694-71559a5d5858.png)


- fixed typo `incorret`



  
  