### PR TITLE
Use BigNumber for determining amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "ark-ts": "^0.3.3",
         "arkjs": "github:arkecosystem/ark-js#master",
         "bcryptjs": "^2.4.3",
+        "bignumber.js": "^5.0.0",
         "bip38": "^2.0.2",
         "bip39": "^2.4.0",
         "chart.js": "^2.7.1",

--- a/src/pages/transaction/transaction-send/transaction-send.ts
+++ b/src/pages/transaction/transaction-send/transaction-send.ts
@@ -24,6 +24,7 @@ import * as constants from '@app/app.constants';
 import { PrivateKey, TransactionSend } from 'ark-ts';
 
 import { AutoCompleteComponent } from 'ionic2-auto-complete';
+import { BigNumber } from 'bignumber.js';
 
 @IonicPage()
 @Component({
@@ -157,8 +158,9 @@ export class TransactionSendPage {
   }
 
   onEnterPinCode(keys: WalletKeys) {
+    let amount = new BigNumber(this.transaction.amount)
     let data: TransactionSend = {
-      amount: Number(this.transaction.amount) * constants.WALLET_UNIT_TO_SATOSHI,
+      amount: amount.times(constants.WALLET_UNIT_TO_SATOSHI).toNumber(),
       vendorField: this.transaction.smartBridge,
       passphrase: keys.key,
       secondPassphrase: keys.secondKey,


### PR DESCRIPTION
Relates to #35 

Fixes rounding issue where amount has a decimal within the transaction itself, when that should never be the case. E.g. Incorrect decimal value `{"amount":8259999999.999999` instead of `8260000000`