### PR TITLE
Open external links in browser

### DIFF
--- a/src/pages/settings/settings.ts
+++ b/src/pages/settings/settings.ts
@@ -73,7 +73,7 @@ export class SettingsPage {
   }
 
   openPrivacyPolicy() {
-    return this.inAppBrowser.create(constants.PRIVACY_POLICY_URL);
+    return this.inAppBrowser.create(constants.PRIVACY_POLICY_URL, '_system');
   }
 
   confirmClearData() {

--- a/src/pages/transaction/transaction-show/transaction-show.ts
+++ b/src/pages/transaction/transaction-show/transaction-show.ts
@@ -53,7 +53,7 @@ export class TransactionShowPage {
 
   openInExplorer() {
     let url = `${this.currentNetwork.explorer}/tx/${this.transaction.id}`;
-    return this.inAppBrowser.create(url);
+    return this.inAppBrowser.create(url, '_system');
   }
 
   presentOptions() {


### PR DESCRIPTION
This PR makes two changes to opening links in the app by adding a '_system' parameter, and solves issue #34 :

* Transactions -> Open in explorer: this will now open in the browser defined by the user, instead of the in-app webview
* Privacy Policy: I have changed this to open in the browser too, but I am not sure if this is necessary. Would love to hear a response from any of you regarding this. My preference goes out to the browser, as I don't like the in-app browser version myself. However, I see how opening the browser for a .txt file can be cumbersome to some and would prefer to simply view it in the app.