### PR TITLE
Enable scanning QR code when adding new contact

### DIFF
--- a/src/pages/contacts/contact-create/contact-create.ts
+++ b/src/pages/contacts/contact-create/contact-create.ts
@@ -4,7 +4,7 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 import { UserDataProvider } from '@providers/user-data/user-data';
 import { ToastProvider } from '@providers/toast/toast';
 
-import { Contact } from '@models/contact';
+import { Contact, QRCodeScheme} from '@models/model';
 import { PublicKey } from 'ark-ts/core';
 
 import { QRScannerComponent } from '@components/qr-scanner/qr-scanner';
@@ -73,13 +73,15 @@ export class ContactCreatePage {
   }
 
   scanQRCode() {
-    this.qrScanner.open();
+    this.qrScanner.open(true);
   }
 
-  onScanQRCode(qrCode: object) {
-    if (qrCode['a']) {
-      this.address = qrCode['a'];
+  onScanQRCode(qrCode: QRCodeScheme) {
+    if (qrCode.address) {
+      this.address = qrCode.address;
       this.validateAddress();
+    } else {
+      this.toastProvider.error('QR_CODE.INVALID_QR_ERROR');
     }
   }
 


### PR DESCRIPTION
When trying to add a new contact, the QR code scanner did not save the address (and did not show an error either). This PR solves that issue and also adds an error message in case the QR did not contain a valid address.