### PR TITLE
Fix pin dots not updating when creating wallet

### DIFF
--- a/src/modals/pin-code/pin-code.ts
+++ b/src/modals/pin-code/pin-code.ts
@@ -46,36 +46,36 @@ export class PinCodeModal {
     // this.vibration.vibrate(constants.VIBRATION_TIME_MS);
 
     if (this.password.length < this.length) {
-      this.zone.runOutsideAngular(() => {
+      this.zone.run(() => {
         this.password = this.password + value;
+      });
 
-        if (this.password.length == this.length) {
+      if (this.password.length == this.length) {
 
-          if (!this.expectedPassword && !this.validatePassword) {
-            return this.dismiss(true);
+        if (!this.expectedPassword && !this.validatePassword) {
+          return this.dismiss(true);
+        }
+
+        // Confirm with the previous entered password
+        if (this.expectedPassword) {
+          if (this.expectedPassword !== this.password) {
+            this.setWrong();
+          } else {
+            this.dismiss(true);
           }
+        }
 
-          // Confirm with the previous entered password
-          if (this.expectedPassword) {
-            if (this.expectedPassword !== this.password) {
+        if (this.validatePassword) {
+          this.authProvider.validateMasterPassword(this.password).subscribe((result) => {
+            if (!result) {
               this.setWrong();
             } else {
               this.dismiss(true);
             }
-          }
-
-          if (this.validatePassword) {
-            this.authProvider.validateMasterPassword(this.password).subscribe((result) => {
-              if (!result) {
-                this.setWrong();
-              } else {
-                this.dismiss(true);
-              }
-            });
-          }
-
+          });
         }
-      });
+
+      }
     }
   }
 


### PR DESCRIPTION
Resolves #47 by updating the pin inside of ngZone so that angular can see the change and update the pin dots.

Looks like this was removed [here](https://github.com/ArkEcosystem/ark-mobile/commit/61878255a6544164dc58af2528604432771b8460#diff-8fe260f49b456b3de01f92aecd299ee4L49) in an attempt to reduce the input lag when entering your pin, but I think the real solution was added in PR #24.