### PR TITLE
Add travis & add better tslint rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+sudo: false
+
+language: node_js
+node_js:
+  - "8"
+
+cache:
+  directories:
+     - ./node_modules
+
+install:
+  - npm install
+
+script:
+  - npm run lint  --bailOnLintError true
+  - npm run build -- --prod

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![ARK Mobile](https://i.imgur.com/0BjkC9C.png)
 
+[![Build Status](https://travis-ci.org/ArkEcosystem/ark-mobile.svg?branch=master)](https://travis-ci.org/ArkEcosystem/ark-mobile)
+
 # Ark Mobile
 > A Wallet for Everyone
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -100,7 +100,7 @@ export class MyApp implements OnInit, OnDestroy {
       if (this.menuCtrl && this.menuCtrl.isOpen()) {
         return this.menuCtrl.close();
       }
-      let navPromise = this.app.navPop();
+      const navPromise = this.app.navPop();
       if (!navPromise) {
         if (this.nav.getActive().name === 'LoginPage' || this.nav.getActive().name === 'IntroPage') {
           this.showConfirmation(this.exitText).then(() => {
@@ -117,7 +117,7 @@ export class MyApp implements OnInit, OnDestroy {
 
   initConfig() {
     // all platforms
-		this.config.set('scrollAssist', false);
+    this.config.set('scrollAssist', false);
     this.config.set('autoFocusAssist', false);
 
     // ios
@@ -143,8 +143,8 @@ export class MyApp implements OnInit, OnDestroy {
       });
 
       this.platform.resume.subscribe(() => {
-        let now = moment();
-        let diff = now.diff(this.lastPauseTimestamp);
+        const now = moment();
+        const diff = now.diff(this.lastPauseTimestamp);
 
         if (diff >= constants.APP_TIMEOUT_DESTROY) {
           const overlay = this.app._appRoot._overlayPortal.getActive();
@@ -213,16 +213,16 @@ export class MyApp implements OnInit, OnDestroy {
 
       this.menuCtrl.enable(false, 'sidebarMenu');
       return this.openPage('LoginPage');
-    })
+    });
   }
 
   // Verify if any account registered is a delegate
   private onUpdateDelegates(delegates: arkts.Delegate[]) {
     lodash.flatMap(this.userDataProvider.profiles, (profile: Profile) => {
-      let wallets = lodash.values(profile.wallets);
+      const wallets = lodash.values(profile.wallets);
       return lodash.filter(wallets, { isDelegate: false });
     }).forEach((wallet: any) => {
-      let find = lodash.find(delegates, { address: wallet['address'] });
+      const find = lodash.find(delegates, { address: wallet['address'] });
 
       if (find) {
         wallet['isDelegate'] = true;
@@ -239,14 +239,14 @@ export class MyApp implements OnInit, OnDestroy {
       .takeUntil(this.unsubscriber$)
       .debounceTime(500)
       .subscribe(() => {
-        this.arkApiProvider.delegates.subscribe((delegates) => this.onUpdateDelegates(delegates))
+        this.arkApiProvider.delegates.subscribe((delegates) => this.onUpdateDelegates(delegates));
       });
   }
 
   private showConfirmation(title: string): Promise<void> {
     return new Promise((resolve) => {
       this.translateService.get(['NO', 'YES']).subscribe((translation) => {
-        let alert = this.alertCtrl.create({
+        const alert = this.alertCtrl.create({
           subTitle: title,
           buttons: [
             {
@@ -266,7 +266,10 @@ export class MyApp implements OnInit, OnDestroy {
   }
 
   private verifyNetwork() {
-    this.ionicNetwork.onDisconnect().takeUntil(this.unsubscriber$).subscribe(() => this.toastProvider.error('NETWORKS_PAGE.INTERNET_DESCONNECTED'));
+    this.ionicNetwork
+      .onDisconnect()
+      .takeUntil(this.unsubscriber$)
+      .subscribe(() => this.toastProvider.error('NETWORKS_PAGE.INTERNET_DESCONNECTED'));
   }
 
   ngOnInit() {

--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -26,7 +26,7 @@ export const TOAST_HIDE_DELAY = 3000;
 export const TOAST_POSITION = 'bottom';
 
 // COIN MARKETCAP API
-export const API_MARKET_URL = "https://min-api.cryptocompare.com";
+export const API_MARKET_URL = 'https://min-api.cryptocompare.com';
 export const API_MARKET_HISTORY_ENDPOINT = 'data/histoday?fsym=ARK&allData=true&tsym=';
 export const API_MARKET_TICKER_ENDPOINT = 'data/pricemultifull?fsyms=ARK&tsyms=';
 
@@ -37,5 +37,5 @@ export const APP_TIMEOUT_DESTROY = 60000;
 
 // ARK
 export const PRIVACY_POLICY_URL = 'https://ark.io/PrivacyPolicy.txt';
-export const URI_QRCODE_SCHEME_PREFIX = "ark:";
+export const URI_QRCODE_SCHEME_PREFIX = 'ark:';
 export const NUM_ACTIVE_DELEGATES = 51;

--- a/src/components/address-list/address-list.ts
+++ b/src/components/address-list/address-list.ts
@@ -8,7 +8,7 @@ import { AddressMap } from '@models/contact';
 export class AddressListComponent {
   @Input() map: AddressMap[];
   @Input() icon: string;
-  @Input() circleProperty: string = 'key'; // key or value
+  @Input() circleProperty = 'key'; // key or value
 
   @Output() onTap: EventEmitter<string> = new EventEmitter<string>();
   @Output() onPress: EventEmitter<string> = new EventEmitter<string>();

--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -7,11 +7,11 @@ import { ClosePopupComponentModule } from './close-popup/close-popup.module';
 import { AddressListComponentModule } from './address-list/address-list.module';
 
 @NgModule({
-	declarations: [
+  declarations: [
     ProgressBarComponent,
   ],
-	imports: [],
-	exports: [
+  imports: [],
+  exports: [
     ProgressBarComponent,
     EmptyListComponentModule,
     PinCodeComponentModule,

--- a/src/components/confirm-transaction/confirm-transaction.ts
+++ b/src/components/confirm-transaction/confirm-transaction.ts
@@ -2,7 +2,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { ArkApiProvider } from '@providers/ark-api/ark-api';
 import { ModalController, NavController } from 'ionic-angular';
 import { Wallet, WalletKeys, Transaction, TranslatableObject } from '@models/model';
-import { TranslateService } from "@ngx-translate/core";
+import { TranslateService } from '@ngx-translate/core';
 
 import lodash from 'lodash';
 
@@ -29,14 +29,14 @@ export class ConfirmTransactionComponent {
 
     this.arkApiProvider.createTransaction(transaction, keys.key, keys.secondKey, keys.secondPassphrase)
       .subscribe((tx) => {
-        let modal = this.modalCtrl.create('ConfirmTransactionModal', {
+        const modal = this.modalCtrl.create('ConfirmTransactionModal', {
           transaction: tx
         }, { cssClass: 'inset-modal-send', enableBackdropDismiss: true });
 
         modal.onDidDismiss((result) => {
-          if (lodash.isUndefined(result)) return;
+          if (lodash.isUndefined(result)) { return; }
 
-          if (!result.status) return this.presentWrongModal(result);
+          if (!result.status) { return this.presentWrongModal(result); }
 
           this.onConfirm.emit(tx);
 
@@ -66,7 +66,7 @@ export class ConfirmTransactionComponent {
   }
 
   presentWrongModal(response) {
-    let responseModal = this.modalCtrl.create('TransactionResponsePage', {
+    const responseModal = this.modalCtrl.create('TransactionResponsePage', {
       response
     }, { cssClass: 'inset-modal-small' });
 

--- a/src/components/pin-code/pin-code.ts
+++ b/src/components/pin-code/pin-code.ts
@@ -29,18 +29,18 @@ export class PinCodeComponent {
   }
 
   open(message: string, outputPassword: boolean, verifySecondPassphrase: boolean = false) {
-    if (outputPassword && !this.wallet) return false;
+    if (outputPassword && !this.wallet) { return false; }
 
-    let modal = this.modalCtrl.create('PinCodeModal', {
+    const modal = this.modalCtrl.create('PinCodeModal', {
       message,
       outputPassword,
       validatePassword: true,
     });
 
     modal.onDidDismiss((password) => {
-      if (lodash.isNil(password)) return this.onWrong.emit();
+      if (lodash.isNil(password)) { return this.onWrong.emit(); }
 
-      let loader = this.loadingCtrl.create({
+      const loader = this.loadingCtrl.create({
         dismissOnPageChange: true,
         enableBackdropDismiss: false,
         showBackdrop: true
@@ -53,12 +53,12 @@ export class PinCodeComponent {
         return this.onSuccess.emit();
       }
 
-      let passphrases = this.userDataProvider.getKeysByWallet(this.wallet, password);
+      const passphrases = this.userDataProvider.getKeysByWallet(this.wallet, password);
       loader.dismiss();
 
-      if (lodash.isEmpty(passphrases) || lodash.isNil(passphrases)) return this.onWrong.emit();
+      if (lodash.isEmpty(passphrases) || lodash.isNil(passphrases)) { return this.onWrong.emit(); }
 
-      if (verifySecondPassphrase) return this.requestSecondPassphrase(passphrases);
+      if (verifySecondPassphrase) { return this.requestSecondPassphrase(passphrases); }
 
       return this.onSuccess.emit(passphrases);
     });
@@ -68,7 +68,7 @@ export class PinCodeComponent {
 
   private requestSecondPassphrase(passphrases: WalletKeys) {
     if (this.wallet.secondSignature && !this.wallet.cipherSecondKey) {
-      let modal = this.modalCtrl.create('EnterSecondPassphraseModal', null, { cssClass: 'inset-modal' });
+      const modal = this.modalCtrl.create('EnterSecondPassphraseModal', null, { cssClass: 'inset-modal' });
 
       modal.onDidDismiss((passphrase) => {
         if (!passphrase) {
@@ -87,16 +87,16 @@ export class PinCodeComponent {
   }
 
   createUpdatePinCode(nextPage?: string, oldPassword?: string) {
-    let createModal = (master?: any) => {
+    const createPinCodeModalFunc = (master?: any) => {
       if (!master) {
-        let createModal = this.modalCtrl.create('PinCodeModal', {
+        const pinCodeModal = this.modalCtrl.create('PinCodeModal', {
           message: 'PIN_CODE.CREATE',
           outputPassword: true,
         });
 
-        createModal.onDidDismiss((password) => {
+        pinCodeModal.onDidDismiss((password) => {
           if (password) {
-            let validateModal = this.modalCtrl.create('PinCodeModal', {
+            const validateModal = this.modalCtrl.create('PinCodeModal', {
               message: 'PIN_CODE.CONFIRM',
               expectedPassword: password,
             });
@@ -122,15 +122,15 @@ export class PinCodeComponent {
           }
         });
 
-        createModal.present();
+        pinCodeModal.present();
       } else if (nextPage) {
         this.navCtrl.push(nextPage);
       }
     };
     if (!oldPassword) {
-      this.authProvider.getMasterPassword().do(createModal).subscribe();
+      this.authProvider.getMasterPassword().do(createPinCodeModalFunc).subscribe();
     } else {
-      createModal();
+      createPinCodeModalFunc();
     }
   }
 

--- a/src/components/qr-code/qr-code.ts
+++ b/src/components/qr-code/qr-code.ts
@@ -18,21 +18,21 @@ export class QRCodeComponent implements OnChanges {
   constructor() { }
 
   ngOnChanges() {
-    if (!this.size) this.size = 80;
+    if (!this.size) { this.size = 80; }
 
-    let params = this.formatParams();
-    let scheme = `${constants.URI_QRCODE_SCHEME_PREFIX}${this.address}${params}`;
+    const params = this.formatParams();
+    const scheme = `${constants.URI_QRCODE_SCHEME_PREFIX}${this.address}${params}`;
 
     this.value = JSON.parse(JSON.stringify(scheme));
   }
 
   private formatParams() {
-    let params = [];
+    const params = [];
 
-    if (this.label) params.push(`label=${this.label}`);
-    if (this.amount) params.push(`amount=${this.amount}`);
-    if (this.vendorField) params.push(`vendorField=${this.vendorField}`);
+    if (this.label) { params.push(`label=${this.label}`); }
+    if (this.amount) { params.push(`amount=${this.amount}`); }
+    if (this.vendorField) { params.push(`vendorField=${this.vendorField}`); }
 
-    return params.length > 0 ? `?${params.join("&")}` : '';
+    return params.length > 0 ? `?${params.join('&')}` : '';
   }
 }

--- a/src/components/qr-scanner/qr-scanner.ts
+++ b/src/components/qr-scanner/qr-scanner.ts
@@ -18,14 +18,14 @@ export class QRScannerComponent {
   constructor(private modalCtrl: ModalController) { }
 
   open(format: boolean = false) {
-    let modal = this.modalCtrl.create('QRScannerModal');
+    const modal = this.modalCtrl.create('QRScannerModal');
 
     modal.onDidDismiss((qrCode) => {
-      if (lodash.isNil(qrCode)) return this.onWrong.emit();
+      if (lodash.isNil(qrCode)) { return this.onWrong.emit(); }
 
       let response = qrCode;
 
-      if (format) response = this.formatScheme(qrCode);
+      if (format) { response = this.formatScheme(qrCode); }
 
       return this.onSuccess.emit(response);
     });
@@ -34,10 +34,10 @@ export class QRScannerComponent {
   }
 
   private formatScheme(qrCode: any): QRCodeScheme {
-    if (lodash.isObject(qrCode)) return this.formatOld(qrCode);
+    if (lodash.isObject(qrCode)) { return this.formatOld(qrCode); }
 
-    let scheme: QRCodeScheme = {};
-    let prefixUriRegex = new RegExp(`${constants.URI_QRCODE_SCHEME_PREFIX}([AaDd]{1}[0-9a-zA-Z]{33})`, 'g');
+    const scheme: QRCodeScheme = {};
+    const prefixUriRegex = new RegExp(`${constants.URI_QRCODE_SCHEME_PREFIX}([AaDd]{1}[0-9a-zA-Z]{33})`, 'g');
 
     if (qrCode.match(prefixUriRegex)) {
       scheme.address = prefixUriRegex.exec(qrCode)[1];
@@ -57,7 +57,7 @@ export class QRScannerComponent {
   }
 
   private formatOld(json): QRCodeScheme {
-    let scheme: QRCodeScheme = {};
+    const scheme: QRCodeScheme = {};
 
     if (json['a'] || json['address']) {
       scheme.address = json['a'] || json['address'];

--- a/src/directives/directives.module.ts
+++ b/src/directives/directives.module.ts
@@ -5,8 +5,8 @@ import { HeaderScrollerDirective } from './header-scroller/header-scroller';
 import { HideOnKeyboardOpenDirective } from './hide-on-keyboard-open/hide-on-keyboard-open';
 
 @NgModule({
-	declarations: [KeyboardAttachDirective, MainnetOnlyDirective, HeaderScrollerDirective, HideOnKeyboardOpenDirective],
-	imports: [],
-	exports: [KeyboardAttachDirective, MainnetOnlyDirective, HeaderScrollerDirective, HideOnKeyboardOpenDirective]
+  declarations: [KeyboardAttachDirective, MainnetOnlyDirective, HeaderScrollerDirective, HideOnKeyboardOpenDirective],
+  imports: [],
+  exports: [KeyboardAttachDirective, MainnetOnlyDirective, HeaderScrollerDirective, HideOnKeyboardOpenDirective]
 })
 export class DirectivesModule {}

--- a/src/directives/header-scroller/header-scroller.ts
+++ b/src/directives/header-scroller/header-scroller.ts
@@ -9,22 +9,22 @@ import { Directive, ElementRef, OnInit } from '@angular/core';
   selector: '[header-scroller]'
 })
 export class HeaderScrollerDirective implements OnInit {
-  private triggerDistance: number = 50;
+  private triggerDistance = 50;
   private el: HTMLElement;
-  private lastScrollTop: number = 0;
-  private lastMargin: number = 0;
+  private lastScrollTop = 0;
+  private lastMargin = 0;
 
   constructor(el: ElementRef) {
     this.el = el.nativeElement;
   }
 
   public ngOnInit() {
-    let el = this.el;
-    let children = el && el.children;
-    let childList = children && <Array<HTMLElement>>Array.from(children);
+    const el = this.el;
+    const children = el && el.children;
+    const childList = children && <Array<HTMLElement>>Array.from(children);
 
-    let scrollList = (childList || []).filter(e => e.classList.contains('scroll-content'));
-    let scroll = scrollList.length ? scrollList[0] : null;
+    const scrollList = (childList || []).filter(e => e.classList.contains('scroll-content'));
+    const scroll = scrollList.length ? scrollList[0] : null;
 
     scroll.style.zIndex = '998';
     scroll.style.backgroundColor = 'inherit';
@@ -36,16 +36,16 @@ export class HeaderScrollerDirective implements OnInit {
 
   private bindScroller(el: HTMLElement): void {
     el.addEventListener('scroll', event => {
-      let scroller = <HTMLElement>event.target;
+      const scroller = <HTMLElement>event.target;
 
-      let header = <HTMLElement>scroller.parentElement.previousElementSibling;
-      let nav = <HTMLElement>scroller.parentElement.previousElementSibling.children[0];
+      const header = <HTMLElement>scroller.parentElement.previousElementSibling;
+      const nav = <HTMLElement>scroller.parentElement.previousElementSibling.children[0];
 
-      let scrollTop = scroller.scrollTop;
-      let scrollerStyle = scroller.style;
+      const scrollTop = scroller.scrollTop;
+      const scrollerStyle = scroller.style;
 
-      let navOffset = nav.offsetHeight;
-      let headerOffset = header.offsetHeight;
+      const navOffset = nav.offsetHeight;
+      const headerOffset = header.offsetHeight;
 
       let newMargin;
       let newPadding;

--- a/src/directives/keyboard-attach/keyboard-attach.ts
+++ b/src/directives/keyboard-attach/keyboard-attach.ts
@@ -43,7 +43,7 @@ export class KeyboardAttachDirective implements OnInit, OnDestroy {
 
   private onShowSubscription: Subscription;
   private onHideSubscription: Subscription;
-  private initialPaddingBottom: number = 0;
+  private initialPaddingBottom = 0;
 
   constructor(
     private elementRef: ElementRef,
@@ -51,7 +51,7 @@ export class KeyboardAttachDirective implements OnInit, OnDestroy {
     private platform: Platform
   ) {
     setTimeout(() => {
-      let computedStyle = window.getComputedStyle(elementRef.nativeElement);
+      const computedStyle = window.getComputedStyle(elementRef.nativeElement);
       this.initialPaddingBottom = parseInt(computedStyle['padding-bottom']) || 0;
     }, 0);
   }
@@ -73,13 +73,13 @@ export class KeyboardAttachDirective implements OnInit, OnDestroy {
   }
 
   private onShow(e) {
-    let keyboardHeight: number = e.keyboardHeight || (e.detail && e.detail.keyboardHeight);
+    const keyboardHeight: number = e.keyboardHeight || (e.detail && e.detail.keyboardHeight);
     this.setElementPosition(keyboardHeight);
-  };
+  }
 
   private onHide() {
     this.setElementPosition(0);
-  };
+  }
 
   private setElementPosition(pixels: number) {
     this.elementRef.nativeElement.style.paddingBottom = pixels + this.initialPaddingBottom + 'px';

--- a/src/modals/confirm-transaction/confirm-transaction.ts
+++ b/src/modals/confirm-transaction/confirm-transaction.ts
@@ -41,7 +41,7 @@ export class ConfirmTransactionModal implements OnDestroy {
     this.transaction = this.navParams.get('transaction');
     this.address = this.transaction.address;
 
-    if (!this.transaction) this.navCtrl.pop();
+    if (!this.transaction) { this.navCtrl.pop(); }
     this.loadingCtrl.create().dismissAll();
 
     this.currentNetwork = this.arkApiProvider.network;
@@ -57,15 +57,15 @@ export class ConfirmTransactionModal implements OnDestroy {
   }
 
   dismiss(status?: boolean, message?: string) {
-    if (lodash.isUndefined(status)) return this.viewCtrl.dismiss();
+    if (lodash.isUndefined(status)) { return this.viewCtrl.dismiss(); }
 
-    let response = { status, message };
+    const response = { status, message };
     this.viewCtrl.dismiss(response);
   }
 
   private onUpdateTicker() {
     this.marketDataProvider.onUpdateTicker$.takeUntil(this.unsubscriber$).do((ticker) => {
-      if (!ticker) return;
+      if (!ticker) { return; }
 
       this.ticker = ticker;
       this.settingsDataProvider.settings.subscribe((settings) => {

--- a/src/modals/generate-entropy/generate-entropy.ts
+++ b/src/modals/generate-entropy/generate-entropy.ts
@@ -20,7 +20,7 @@ export class GenerateEntropyModal {
   private count: number;
   private total: number;
 
-  private finished: boolean = false;
+  private finished = false;
 
   constructor(
     public navCtrl: NavController,
@@ -34,14 +34,14 @@ export class GenerateEntropyModal {
 
   panEvent(e) {
     this.pan++;
-    if (this.finished) return;
+    if (this.finished) { return; }
 
-    if (e.isFinal || e.isFirst) return;
+    if (e.isFinal || e.isFirst) { return; }
 
     let pos;
-    let available = [];
+    const available = [];
 
-    for (let i in this.bytes) {
+    for (const i in this.bytes) {
       if (!this.bytes[i]) {
         available.push(i);
       }
@@ -63,7 +63,7 @@ export class GenerateEntropyModal {
     this.progress = parseInt(Number(this.count / this.total * 100).toString());
 
     if (this.count > this.total) {
-      let hex = this.entropy.map(v => this.lpad(v.toString(16), '0', 2)).join('');
+      const hex = this.entropy.map(v => this.lpad(v.toString(16), '0', 2)).join('');
       this.finished = true;
       this.dismiss(hex);
     }
@@ -81,8 +81,8 @@ export class GenerateEntropyModal {
   }
 
   lpad(str, pad, length) {
-    while (str.length < length) str = pad + str
-    return str
+    while (str.length < length) { str = pad + str; }
+    return str;
   }
 
   dismiss(result?) {

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.module.ts
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
 
 import { TranslateModule } from '@ngx-translate/core';
-import {PassphraseWordTesterModal} from "./passphrase-word-tester";
+import {PassphraseWordTesterModal} from './passphrase-word-tester';
 
 @NgModule({
   declarations: [

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.ts
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.ts
@@ -1,6 +1,6 @@
 import {Component} from '@angular/core';
 import {IonicPage, NavController, NavParams, ViewController} from 'ionic-angular';
-import {PassphraseWord} from "@models/passphrase-word";
+import {PassphraseWord} from '@models/passphrase-word';
 
 @IonicPage()
 @Component({

--- a/src/modals/pin-code/pin-code.ts
+++ b/src/modals/pin-code/pin-code.ts
@@ -15,16 +15,16 @@ export class PinCodeModal {
 
   public message: string;
   public password: string;
-  public isWrong: boolean = false;
+  public isWrong = false;
 
   // Send a password created before, useful for create pin and confirm
   private expectedPassword: string;
   // Will send back the entered password
-  private outputPassword: boolean = false;
+  private outputPassword = false;
   // Check if the entered password is correct
-  private validatePassword: boolean = false;
+  private validatePassword = false;
 
-  private length: number = 6;
+  private length = 6;
 
 
   constructor(
@@ -50,7 +50,7 @@ export class PinCodeModal {
         this.password = this.password + value;
       });
 
-      if (this.password.length == this.length) {
+        if (this.password.length === this.length) {
 
         if (!this.expectedPassword && !this.validatePassword) {
           return this.dismiss(true);
@@ -104,7 +104,7 @@ export class PinCodeModal {
   }
 
   dismiss(status: boolean = true) {
-    if (this.password.length < this.length) return this.viewCtrl.dismiss();
+    if (this.password.length < this.length) { return this.viewCtrl.dismiss(); }
 
     if (this.outputPassword) {
       this.viewCtrl.dismiss(this.password);

--- a/src/modals/qr-scanner/qr-scanner.ts
+++ b/src/modals/qr-scanner/qr-scanner.ts
@@ -32,8 +32,8 @@ export class QRScannerModal {
     this.qrScanner.prepare()
     .then((status: QRScannerStatus) => {
       if (status.authorized) {
-        this.ionApp = <HTMLElement>document.getElementsByTagName("ion-app")[0];
-        let scanSub = this.qrScanner.scan().subscribe((qrCode: string) => {
+        this.ionApp = <HTMLElement>document.getElementsByTagName('ion-app')[0];
+        const scanSub = this.qrScanner.scan().subscribe((qrCode: string) => {
           this.vibration.vibrate(constants.VIBRATION_TIME_MS);
 
           let response;

--- a/src/modals/wallet-backup/wallet-backup.ts
+++ b/src/modals/wallet-backup/wallet-backup.ts
@@ -5,7 +5,7 @@ import { UserDataProvider } from '@providers/user-data/user-data';
 import { PrivateKey } from 'ark-ts/core';
 import bip39 from 'bip39';
 import { WalletKeys, AccountBackup, PassphraseWord } from '@models/model';
-import { ArkUtility } from "../../utils/ark-utility";
+import { ArkUtility } from '../../utils/ark-utility';
 
 @IonicPage()
 @Component({
@@ -18,7 +18,7 @@ export class WalletBackupModal {
   public entropy: string;
   public keys: WalletKeys;
   public message: string;
-  public showAdvancedOptions: boolean = false;
+  public showAdvancedOptions = false;
 
   public account: AccountBackup;
 
@@ -35,7 +35,7 @@ export class WalletBackupModal {
     this.keys = this.navParams.get('keys');
     this.message = this.navParams.get('message');
 
-    if (!this.title || (!this.entropy && !this.keys)) this.dismiss();
+    if (!this.title || (!this.entropy && !this.keys)) { this.dismiss(); }
 
     this.currentNetwork = this.userDataProvider.currentNetwork;
   }
@@ -45,7 +45,7 @@ export class WalletBackupModal {
       this.dismiss(this.account);
     }
 
-    let wordTesterModal = this.modalCtrl.create('PassphraseWordTesterModal', {
+    const wordTesterModal = this.modalCtrl.create('PassphraseWordTesterModal', {
       words: this.getRandomWords(3, this.account.mnemonic.split(' '))
     });
 
@@ -90,13 +90,13 @@ export class WalletBackupModal {
   }
 
   private generateAccountFromKeys() {
-    let pvKey = PrivateKey.fromSeed(this.keys.key, this.currentNetwork);
-    let pbKey = pvKey.getPublicKey();
+    const pvKey = PrivateKey.fromSeed(this.keys.key, this.currentNetwork);
+    const pbKey = pvKey.getPublicKey();
     pbKey.setNetwork(this.currentNetwork);
 
-    let wallet = this.userDataProvider.getWalletByAddress(pbKey.getAddress());
+    const wallet = this.userDataProvider.getWalletByAddress(pbKey.getAddress());
 
-    let account: AccountBackup = {};
+    const account: AccountBackup = {};
     account.address = wallet.address;
     account.mnemonic = this.keys.key;
     account.publicKey = pbKey.toHex();
@@ -111,13 +111,13 @@ export class WalletBackupModal {
   }
 
   private generateAccountFromEntropy() {
-    let account: AccountBackup = {};
+    const account: AccountBackup = {};
 
     account.entropy = this.entropy;
     account.mnemonic = bip39.entropyToMnemonic(account.entropy);
 
-    let pvKey = PrivateKey.fromSeed(account.mnemonic, this.currentNetwork);
-    let pbKey = pvKey.getPublicKey();
+    const pvKey = PrivateKey.fromSeed(account.mnemonic, this.currentNetwork);
+    const pbKey = pvKey.getPublicKey();
 
     account.address = pbKey.getAddress();
     account.publicKey = pbKey.toHex();

--- a/src/models/market.ts
+++ b/src/models/market.ts
@@ -8,84 +8,84 @@ export interface Currency {
 
 export const CURRENCIES_LIST: Currency[] = [
   {
-    code: "btc",
-    name: "Bitcoin",
-    symbol: "Ƀ",
+    code: 'btc',
+    name: 'Bitcoin',
+    symbol: 'Ƀ',
   },
   {
-    code: "usd",
-    name: "Dollar",
-    symbol: "$",
+    code: 'usd',
+    name: 'Dollar',
+    symbol: '$',
   },
   {
-    code: "eur",
-    name: "Euro",
-    symbol: "€",
+    code: 'eur',
+    name: 'Euro',
+    symbol: '€',
   },
   {
-    code: "gbp",
-    name: "British Pound",
-    symbol: "£",
+    code: 'gbp',
+    name: 'British Pound',
+    symbol: '£',
   },
   {
-    code: "krw",
-    name: "South Korean Won",
-    symbol: "₩",
+    code: 'krw',
+    name: 'South Korean Won',
+    symbol: '₩',
   },
   {
-    code: "cny",
-    name: "Chinese Yuan",
-    symbol: "CN¥",
+    code: 'cny',
+    name: 'Chinese Yuan',
+    symbol: 'CN¥',
   },
   {
-    code: "jpy",
-    name: "Japanese Yen",
-    symbol: "¥",
+    code: 'jpy',
+    name: 'Japanese Yen',
+    symbol: '¥',
   },
   {
-    code: "aud",
-    name: "Australian Dollar",
-    symbol: "A$",
+    code: 'aud',
+    name: 'Australian Dollar',
+    symbol: 'A$',
   },
   {
-    code: "cad",
-    name: "Canadian Dollar",
-    symbol: "CA$",
+    code: 'cad',
+    name: 'Canadian Dollar',
+    symbol: 'CA$',
   },
   {
-    code: "rub",
-    name: "Russian Ruble",
-    symbol: "RUB",
+    code: 'rub',
+    name: 'Russian Ruble',
+    symbol: 'RUB',
   },
   {
-    code: "inr",
-    name: "Indian Rupee",
-    symbol: "₹",
+    code: 'inr',
+    name: 'Indian Rupee',
+    symbol: '₹',
   },
   {
-    code: "brl",
-    name: "Brazilian Real",
-    symbol: "R$",
+    code: 'brl',
+    name: 'Brazilian Real',
+    symbol: 'R$',
   },
   {
-    code: "chf",
-    name: "Swiss Franc",
-    symbol: "CHF",
+    code: 'chf',
+    name: 'Swiss Franc',
+    symbol: 'CHF',
   },
   {
-    code: "hkd",
-    name: "Hong Kong Dollar",
-    symbol: "HK$",
+    code: 'hkd',
+    name: 'Hong Kong Dollar',
+    symbol: 'HK$',
   },
   {
-    code: "idr",
-    name: "Indonesian Rupiah",
-    symbol: "IDR",
+    code: 'idr',
+    name: 'Indonesian Rupiah',
+    symbol: 'IDR',
   },
   {
-    code: "mxn",
-    name: "Mexican Peso",
-    symbol: "MX$",
+    code: 'mxn',
+    name: 'Mexican Peso',
+    symbol: 'MX$',
   },
 ];
 
@@ -120,11 +120,11 @@ export class MarketTicker {
   market: MarketCurrency[];
 
   constructor(data?: any) {
-    if (!data) return;
+    if (!data) { return; }
 
-    let self: any = this;
+    const self: any = this;
 
-    for (let prop in data) {
+    for (const prop in data) {
       self[prop] = data[prop];
     }
 
@@ -136,20 +136,20 @@ export class MarketTicker {
   }
 
   deserialize(input: any): MarketTicker {
-    let self: any = this;
-    if (!input || !lodash.isObject(input)) return;
+    const self: any = this;
+    if (!input || !lodash.isObject(input)) { return; }
 
     self.info = {
       identifier: input.symbol,
       name: input.symbol,
       symbol: input.symbol,
-    }
+    };
 
-    let currencies: MarketCurrency[] = [];
+    const currencies: MarketCurrency[] = [];
 
-    for (let currency of CURRENCIES_LIST) {
-      let currencyCode = currency.code.toUpperCase();
-      let marketCurrency: MarketCurrency = new MarketCurrency();
+    for (const currency of CURRENCIES_LIST) {
+      const currencyCode = currency.code.toUpperCase();
+      const marketCurrency: MarketCurrency = new MarketCurrency();
       marketCurrency.fromCurrency(currency);
 
       marketCurrency.price = 0.0;
@@ -181,14 +181,14 @@ export class MarketHistory {
   history: any;
 
   deserialize(input: any): MarketHistory {
-    let self: any = this;
-    if (!input || !lodash.isObject(input)) return;
+    const self: any = this;
+    if (!input || !lodash.isObject(input)) { return; }
 
-    let history = {};
+    const history = {};
 
-    for (let currency in input) {
-      for (let data of input[currency]) {
-        let date = (new Date(data.time * 1000)).setHours(0, 0, 0, 0);
+    for (const currency in input) {
+      for (const data of input[currency]) {
+        const date = (new Date(data.time * 1000)).setHours(0, 0, 0, 0);
         if (!history[currency]) {
           history[currency] = {};
         }
@@ -202,14 +202,14 @@ export class MarketHistory {
   }
 
   getPriceByDate(currencyCode: string, date: Date): number {
-    let timestampDate = date.setHours(0, 0, 0, 0);
+    const timestampDate = date.setHours(0, 0, 0, 0);
 
     return this.history[currencyCode.toUpperCase()][timestampDate];
   }
 
   getLastWeekPrice(currencyCode: string): any {
-    let dates = lodash(this.history[currencyCode]).keys().takeRight(7).value().map((date) => { return new Date(parseInt(date)) });
-    let prices = lodash(this.history[currencyCode]).values().takeRight(7).value();
+    const dates = lodash(this.history[currencyCode]).keys().takeRight(7).value().map((date) => new Date(parseInt(date)));
+    const prices = lodash(this.history[currencyCode]).values().takeRight(7).value();
 
     return { dates, prices };
   }

--- a/src/models/passphrase-word.ts
+++ b/src/models/passphrase-word.ts
@@ -9,6 +9,6 @@ export class PassphraseWord {
   }
 
   public get isCorrect(): boolean {
-    return this.userValue == this.passphraseValue;
+    return this.userValue === this.passphraseValue;
   }
 }

--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -6,9 +6,9 @@ export class Profile {
 
   deserialize(input: any): Profile {
     this.reset();
-    let self: any = this;
+    const self: any = this;
 
-    for (let prop in input) {
+    for (const prop in input) {
       self[prop] = input[prop];
     }
     return self;

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -4,10 +4,10 @@ export class UserSettings {
   public darkMode: boolean;
   public notification: boolean;
 
-  constructor() {};
+  constructor() {}
 
   public static defaults(): UserSettings {
-    let settings = new UserSettings();
+    const settings = new UserSettings();
     settings.language = 'en';
     settings.currency = 'usd';
     settings.darkMode = false;

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -32,16 +32,15 @@ export interface SendTransactionForm {
 export class Transaction extends TransactionModel {
 
   public date: Date;
-  public totalAmount: number;
 
   constructor(public address: string) {
     super();
   }
 
   deserialize(input: any): Transaction {
-    let self: any = this;
+    const self: any = this;
 
-    for (let prop in input) {
+    for (const prop in input) {
       self[prop] = input[prop];
     }
 
@@ -53,24 +52,24 @@ export class Transaction extends TransactionModel {
   getAmount() {
     let amount = this.amount;
 
-    if (this.isSender()) amount = this.amount + this.fee;
+    if (this.isSender()) { amount = this.amount + this.fee; }
 
     return amount;
   }
 
   getAmountEquivalent(marketCurrency: MarketCurrency, market: MarketTicker | MarketHistory): number {
-    if (!market || !marketCurrency) return 0;
+    if (!market || !marketCurrency) { return 0; }
 
     let price = 0;
     if (market instanceof MarketTicker) {
-      let currency = market ? market.getCurrency({ code: marketCurrency.code }) : null;
+      const currency = market ? market.getCurrency({ code: marketCurrency.code }) : null;
       price = currency ? currency.price : 0;
     } else {
       price = market.getPriceByDate(marketCurrency.code, this.date);
     }
 
-    let unitsSatoshiPipe = new UnitsSatoshiPipe();
-    let amount = unitsSatoshiPipe.transform(this.getAmount(), true);
+    const unitsSatoshiPipe = new UnitsSatoshiPipe();
+    const amount = unitsSatoshiPipe.transform(this.getAmount(), true);
 
     return amount * price;
   }
@@ -86,7 +85,7 @@ export class Transaction extends TransactionModel {
     if (this.isTransfer()) {
       if (this.isSender()) {
         return this.recipientId;
-      } else if (this.isReceiver(this.address)) {
+      } else if (this.isReceiver()) {
         return this.senderId;
       }
     }
@@ -95,7 +94,7 @@ export class Transaction extends TransactionModel {
   getTypeLabel(): string {
     let type = TX_TYPES[this.type];
 
-    if (this.isTransfer() && !this.isSender()) type = 'TRANSACTIONS_PAGE.RECEIVED';
+    if (this.isTransfer() && !this.isSender()) { type = 'TRANSACTIONS_PAGE.RECEIVED'; }
 
     return type;
   }
@@ -103,25 +102,21 @@ export class Transaction extends TransactionModel {
   getActivityLabel() {
     let type = TX_TYPES_ACTIVITY[this.type];
 
-    if (this.isTransfer() && !this.isSender()) type = 'TRANSACTIONS_PAGE.RECEIVED_FROM';
+    if (this.isTransfer() && !this.isSender()) { type = 'TRANSACTIONS_PAGE.RECEIVED_FROM'; }
 
     return type;
   }
 
   isTransfer(): boolean {
-    return this.type == TransactionType.SendArk;
-  }
-
-  isSameAddress(): boolean {
-    return this.senderId == this.recipientId;
+    return this.type === TransactionType.SendArk;
   }
 
   isSender(): boolean {
-    return this.senderId == this.address;
+    return this.senderId === this.address;
   }
 
-  isReceiver(address: string): boolean {
-    return this.recipientId == this.address;
+  isReceiver(): boolean {
+    return this.recipientId === this.address;
   }
 
 }

--- a/src/models/wallet.ts
+++ b/src/models/wallet.ts
@@ -55,9 +55,9 @@ export class Wallet extends Account {
   }
 
   deserialize(input: any): Wallet {
-    let self: any = this;
+    const self: any = this;
 
-    for (let prop in input) {
+    for (const prop in input) {
       self[prop] = input[prop];
     }
     return self;
@@ -65,7 +65,7 @@ export class Wallet extends Account {
 
   reset() {
     this.label = null;
-    this.balance = "0";
+    this.balance = '0';
     this.isDelegate =  false;
     this.username = null;
     this.transactions = [];
@@ -77,12 +77,12 @@ export class Wallet extends Account {
   }
 
   loadTransactions(transactions: any) {
-    if (!Array.isArray(transactions) || transactions.length <= 0) return;
+    if (!Array.isArray(transactions) || transactions.length <= 0) { return; }
 
     this.transactions = [];
 
-    for (let tx of transactions) {
-      let transaction = new Transaction(this.address);
+    for (const tx of transactions) {
+      const transaction = new Transaction(this.address);
       transaction.deserialize(tx);
 
       this.transactions.push(transaction);
@@ -94,8 +94,8 @@ export class Wallet extends Account {
   }
 
   getBalanceEquivalent(currency: MarketCurrency) {
-    let balance = this.getBalance() || 0;
-    let price = currency ? currency.price : 0;
+    const balance = this.getBalance() || 0;
+    const price = currency ? currency.price : 0;
 
     return balance * price;
   }

--- a/src/pages/contacts/contact-create/contact-create.ts
+++ b/src/pages/contacts/contact-create/contact-create.ts
@@ -9,7 +9,7 @@ import { PublicKey } from 'ark-ts/core';
 import { QRScannerComponent } from '@components/qr-scanner/qr-scanner';
 
 import lodash from 'lodash';
-import { ToastProvider } from "@providers/toast/toast";
+import { ToastProvider } from '@providers/toast/toast';
 
 @IonicPage()
 @Component({
@@ -34,7 +34,7 @@ export class ContactCreatePage {
     private userDataProvider: UserDataProvider,
     private toastProvider: ToastProvider
   ) {
-    let param = this.navParams.get('contact');
+    const param = this.navParams.get('contact');
     this.address = this.navParams.get('address');
 
     this.isNew = lodash.isEmpty(param);
@@ -44,9 +44,9 @@ export class ContactCreatePage {
   }
 
   validateAddress() {
-    let validate = PublicKey.validateAddress(this.address, this.currentNetwork);
+    const validate = PublicKey.validateAddress(this.address, this.currentNetwork);
     this.createContactForm.form.controls['address'].setErrors({ incorrect: !validate });
-    if (validate) this.createContactForm.form.controls['address'].setErrors(null);
+    if (validate) { this.createContactForm.form.controls['address'].setErrors(null); }
 
     return validate;
   }

--- a/src/pages/contacts/contact-list/contact-list.ts
+++ b/src/pages/contacts/contact-list/contact-list.ts
@@ -35,7 +35,7 @@ export class ContactListPage {
 
   presentContactActionSheet(address) {
     this.translateService.get(['EDIT', 'DELETE']).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let buttons = [
+      const buttons = [
         {
           text: translation.EDIT,
           role: 'label',
@@ -53,7 +53,7 @@ export class ContactListPage {
         }
       ];
 
-      let action = this.actionSheetCtrl.create({buttons});
+      const action = this.actionSheetCtrl.create({buttons});
       action.present();
     });
   }
@@ -64,7 +64,7 @@ export class ContactListPage {
       'CONFIRM',
       'ARE_YOU_SURE',
     ]).subscribe((translation) => {
-      let alert = this.alertCtrl.create({
+      const alert = this.alertCtrl.create({
         title: translation.ARE_YOU_SURE,
         buttons: [
           {
@@ -80,7 +80,7 @@ export class ContactListPage {
       });
 
       alert.present();
-    })
+    });
   }
 
   isEmpty() {
@@ -93,7 +93,7 @@ export class ContactListPage {
   }
 
   openEditPage(address) {
-    let contact = this.contacts[address];
+    const contact = this.contacts[address];
     return this.navCtrl.push('ContactCreatePage', { address, contact });
   }
 

--- a/src/pages/delegates/delegate-detail/delegate-detail.ts
+++ b/src/pages/delegates/delegate-detail/delegate-detail.ts
@@ -21,7 +21,7 @@ import { ToastProvider } from '@providers/toast/toast';
 export class DelegateDetailPage {
 
   public delegate: Delegate;
-  public qraddress: string = '{a: ""}';
+  public qraddress = '{a: ""}';
   public fees: Fees;
   public currentNetwork: Network;
   public currentWallet: Wallet;
@@ -47,7 +47,7 @@ export class DelegateDetailPage {
 
     this.arkApiProvider.fees.subscribe((fees) => this.fees = fees);
 
-    if (!this.delegate) this.navCtrl.pop();
+    if (!this.delegate) { this.navCtrl.pop(); }
   }
 
   isSameDelegate() {
@@ -69,7 +69,7 @@ export class DelegateDetailPage {
   }
 
   submit() {
-    if (!this.currentWallet) return false;
+    if (!this.currentWallet) { return false; }
 
     if (this.walletVote && this.walletVote.publicKey !== this.delegate.publicKey) {
       this.translateService.get([
@@ -78,7 +78,7 @@ export class DelegateDetailPage {
         'DELEGATES_PAGE.UNVOTE'
       ], { delegate: this.walletVote.username })
         .subscribe((translation) => {
-          let alert = this.alertCtrl.create({
+          const alert = this.alertCtrl.create({
             title: translation['DELEGATES_PAGE.UNVOTE'],
             message: translation['DELEGATES_PAGE.UNVOTE_CURRENT_DELEGATE'],
             buttons: [{
@@ -89,10 +89,10 @@ export class DelegateDetailPage {
                 this.unvote();
               }
             }]
-          })
+          });
 
           alert.present();
-        })
+        });
     } else {
       this.dismiss(this.delegate);
     }

--- a/src/pages/delegates/delegates.ts
+++ b/src/pages/delegates/delegates.ts
@@ -23,17 +23,17 @@ export class DelegatesPage implements OnDestroy {
   @ViewChild('pinCode') pinCode: PinCodeComponent;
   @ViewChild('confirmTransaction') confirmTransaction: ConfirmTransactionComponent;
 
-  public isSearch: boolean = false;
+  public isSearch = false;
   public searchQuery: any = { username: ''};
 
   public delegates: Delegate[];
   public activeDelegates: Delegate[];
   public standByDelegates: Delegate[];
 
-  public supply: number = 0;
+  public supply = 0;
   public preMinned: number = constants.BLOCKCHAIN_PREMINNED;
 
-  public rankStatus: string = 'active';
+  public rankStatus = 'active';
   public currentNetwork: Network;
   public slides: string[] = [
     'active',
@@ -62,13 +62,13 @@ export class DelegatesPage implements OnDestroy {
   openDetailModal(delegate: Delegate) {
     this.selectedDelegate = delegate;
 
-    let modal = this.modalCtrl.create('DelegateDetailPage', {
+    const modal = this.modalCtrl.create('DelegateDetailPage', {
       delegate,
       vote: this.walletVote,
     }, { cssClass: 'inset-modal-large', showBackdrop: false, enableBackdropDismiss: true });
 
     modal.onDidDismiss((voter) => {
-      if (!voter) return;
+      if (!voter) { return; }
 
       this.pinCode.open('PIN_CODE.TYPE_PIN_SIGN_TRANSACTION', true, true);
 
@@ -91,7 +91,7 @@ export class DelegatesPage implements OnDestroy {
   }
 
   getTotalForged() {
-    let forged = this.supply === 0 ? 0 : this.supply - this.preMinned;
+    const forged = this.supply === 0 ? 0 : this.supply - this.preMinned;
 
     return forged;
   }
@@ -107,9 +107,9 @@ export class DelegatesPage implements OnDestroy {
   generateTransaction(keys: WalletKeys) {
     let type = VoteType.Add;
 
-    if (this.walletVote && this.walletVote.publicKey === this.selectedDelegate.publicKey) type = VoteType.Remove;
+    if (this.walletVote && this.walletVote.publicKey === this.selectedDelegate.publicKey) { type = VoteType.Remove; }
 
-    let data: TransactionVote = {
+    const data: TransactionVote = {
       delegatePublicKey: this.selectedDelegate.publicKey,
       passphrase: keys.key,
       secondPassphrase: keys.secondKey,
@@ -122,7 +122,7 @@ export class DelegatesPage implements OnDestroy {
   }
 
   private fetchCurrentVote() {
-    if (!this.currentWallet) return;
+    if (!this.currentWallet) { return; }
 
     this.arkApiProvider.api.account
       .votes({ address: this.currentWallet.address })
@@ -140,7 +140,7 @@ export class DelegatesPage implements OnDestroy {
     this.arkApiProvider.onUpdateDelegates$
       .takeUntil(this.unsubscriber$)
       .do((delegates) => {
-        this.zone.run(() => this.delegates = delegates)
+        this.zone.run(() => this.delegates = delegates);
       })
       .subscribe();
   }
@@ -158,7 +158,7 @@ export class DelegatesPage implements OnDestroy {
 
     this.onUpdateDelegates();
     this.fetchCurrentVote();
-    this.arkApiProvider.fetchDelegates(constants.NUM_ACTIVE_DELEGATES*2).subscribe();
+    this.arkApiProvider.fetchDelegates(constants.NUM_ACTIVE_DELEGATES * 2).subscribe();
   }
 
   ngOnDestroy() {

--- a/src/pages/intro/intro.ts
+++ b/src/pages/intro/intro.ts
@@ -12,9 +12,9 @@ import { TranslateService } from '@ngx-translate/core';
 export class IntroPage {
   @ViewChild(Slides) slider: Slides;
 
-  public showSkip: boolean = true;
+  public showSkip = true;
   public slides: any;
-  public activeIndex: number = 0;
+  public activeIndex = 0;
 
   constructor(
     private navCtrl: NavController,
@@ -63,10 +63,10 @@ export class IntroPage {
   }
 
   slideChanged() {
-    let activeIndex = this.slider.getActiveIndex();
-    let slideLength = this.slider.length();
+    const activeIndex = this.slider.getActiveIndex();
+    const slideLength = this.slider.length();
 
-    if (activeIndex >= slideLength) return;
+    if (activeIndex >= slideLength) { return; }
 
     this.activeIndex = activeIndex;
     this.showSkip = !this.slider.isEnd();

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -14,8 +14,8 @@ import lodash from 'lodash';
 export class LoginPage {
   @ViewChild('pinCode') pinCode: PinCodeComponent;
 
-  public hasProfiles: boolean = false;
-  public isReady: boolean = false;
+  public hasProfiles = false;
+  public isReady = false;
 
   constructor(
     public navCtrl: NavController,

--- a/src/pages/network-status/network-status.ts
+++ b/src/pages/network-status/network-status.ts
@@ -1,8 +1,10 @@
 import {Component, NgZone, OnDestroy} from '@angular/core';
 import { IonicPage, LoadingController } from 'ionic-angular';
 
-import { Subject } from 'rxjs';
+import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/takeUntil';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/debounceTime';
 
 import { ArkApiProvider } from '@providers/ark-api/ark-api';
 
@@ -69,8 +71,9 @@ export class NetworkStatusPage implements OnDestroy {
     this.arkApiProvider.onUpdatePeer$
       .takeUntil(this.unsubscriber$)
       .do((peer) => {
-        if (this.loader) this.loader.dismiss();
-        this.translateService.get('NETWORKS_PAGE.PEER_SUCCESSFULLY_CHANGED').subscribe((translate) => this.toastProvider.success(translate));
+        if (this.loader) { this.loader.dismiss(); }
+        this.translateService.get('NETWORKS_PAGE.PEER_SUCCESSFULLY_CHANGED')
+          .subscribe((translate) => this.toastProvider.success(translate));
         this.zone.run(() => this.currentPeer = peer);
       }).subscribe();
   }

--- a/src/pages/profiles/profile-create/profile-create.ts
+++ b/src/pages/profiles/profile-create/profile-create.ts
@@ -21,7 +21,7 @@ export class ProfileCreatePage implements OnDestroy {
   public networksIds;
 
   public newProfile = { name: '', networkId: '' };
-  public showAdvancedOptions: boolean = false;
+  public showAdvancedOptions = false;
 
   private unsubscriber$: Subject<void> = new Subject<void>();
 
@@ -37,7 +37,7 @@ export class ProfileCreatePage implements OnDestroy {
   }
 
   submitForm() {
-    let profile = new Profile();
+    const profile = new Profile();
     profile.name = this.newProfile.name;
     profile.networkId = this.newProfile.networkId;
 

--- a/src/pages/profiles/profile-signin/profile-signin.ts
+++ b/src/pages/profiles/profile-signin/profile-signin.ts
@@ -46,7 +46,7 @@ export class ProfileSigninPage implements OnDestroy {
 
   presentProfileActionSheet(profileId: string) {
     this.translateService.get(['EDIT', 'DELETE']).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let buttons = [{
+      const buttons = [{
         text: translation.DELETE,
         role: 'delete',
         icon: !this.platform.is('ios') ? 'ios-trash-outline' : '',
@@ -59,7 +59,7 @@ export class ProfileSigninPage implements OnDestroy {
         },
       }];
 
-      let action = this.actionSheetCtrl.create({buttons});
+      const action = this.actionSheetCtrl.create({buttons});
       action.present();
     });
   }
@@ -70,7 +70,7 @@ export class ProfileSigninPage implements OnDestroy {
 
   showDeleteConfirm(profileId: string) {
     this.translateService.get(['ARE_YOU_SURE', 'CONFIRM', 'CANCEL']).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let confirm = this.alertCtrl.create({
+      const confirm = this.alertCtrl.create({
         title: translation.ARE_YOU_SURE,
         buttons: [
           {
@@ -100,7 +100,7 @@ export class ProfileSigninPage implements OnDestroy {
   }
 
   signin() {
-    if (!this.profileIdSelected) return;
+    if (!this.profileIdSelected) { return; }
 
     this.authProvider.login(this.profileIdSelected).takeUntil(this.unsubscriber$).subscribe((status) => {
       if (status) {
@@ -120,9 +120,9 @@ export class ProfileSigninPage implements OnDestroy {
     this.networks = this.userDataProvider.networks;
 
     this.addresses = lodash(this.profiles).mapValues((o) => [o.name, o.networkId]).transform((result, data, id) => {
-      let network = this.networks[data[1]];
-      let networkName = lodash.capitalize(network.name);
-      let isMainnet = network.type === NetworkType.Mainnet;
+      const network = this.networks[data[1]];
+      const networkName = lodash.capitalize(network.name);
+      const isMainnet = network.type === NetworkType.Mainnet;
 
       result.push({ index: id, key: data[0], value: networkName, highlight: isMainnet });
     }, []).value();
@@ -143,9 +143,9 @@ export class ProfileSigninPage implements OnDestroy {
   }
 
   private profileHasWallets(profileId: string): boolean {
-    let profile = this.profiles[profileId];
-    let network = this.networks[profile.networkId];
-    for (let wallet of lodash.values(profile.wallets)) {
+    const profile = this.profiles[profileId];
+    const network = this.networks[profile.networkId];
+    for (const wallet of lodash.values(profile.wallets)) {
       if (PublicKey.validateAddress(wallet.address, network)) {
         return true;
       }

--- a/src/pages/settings/settings.ts
+++ b/src/pages/settings/settings.ts
@@ -14,7 +14,7 @@ import { PinCodeComponent } from '@components/pin-code/pin-code';
 
 import * as constants from '@app/app.constants';
 
-let packageJson = require('@root/package.json');
+const packageJson = require('@root/package.json');
 
 @IonicPage()
 @Component({
@@ -49,7 +49,7 @@ export class SettingsPage implements OnInit, OnDestroy {
   }
 
   openChangePinPage() {
-    let modal = this.modalCtrl.create('PinCodeModal', {
+    const modal = this.modalCtrl.create('PinCodeModal', {
       message: 'PIN_CODE.DEFAULT_MESSAGE',
       outputPassword: true,
       validatePassword: true,
@@ -64,7 +64,7 @@ export class SettingsPage implements OnInit, OnDestroy {
   }
 
   openWalletBackupPage() {
-    if (!this.currentWallet || this.currentWallet.isWatchOnly) return this.presentSelectWallet();
+    if (!this.currentWallet || this.currentWallet.isWatchOnly) { return this.presentSelectWallet(); }
 
     this.onEnterPinCode = this.showBackup;
     this.pinCode.open('PIN_CODE.DEFAULT_MESSAGE', true);
@@ -81,7 +81,7 @@ export class SettingsPage implements OnInit, OnDestroy {
       'ARE_YOU_SURE',
       'SETTINGS_PAGE.CLEAR_DATA_TEXT',
     ]).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let confirm = this.alertCtrl.create({
+      const confirm = this.alertCtrl.create({
         title: translation.ARE_YOU_SURE,
         message: translation['SETTINGS_PAGE.CLEAR_DATA_TEXT'],
         buttons: [
@@ -107,9 +107,11 @@ export class SettingsPage implements OnInit, OnDestroy {
       'SETTINGS_PAGE.SELECT_WALLET_FIRST_TEXT',
       'SETTINGS_PAGE.NOT_AVAILABLE_WATCH_ONLY',
     ]).subscribe((translation) => {
-      let message = this.currentWallet && this.currentWallet.isWatchOnly ? translation['SETTINGS_PAGE.NOT_AVAILABLE_WATCH_ONLY'] : translation['SETTINGS_PAGE.SELECT_WALLET_FIRST_TEXT'];
+      const message = this.currentWallet && this.currentWallet.isWatchOnly
+        ? translation['SETTINGS_PAGE.NOT_AVAILABLE_WATCH_ONLY']
+        : translation['SETTINGS_PAGE.SELECT_WALLET_FIRST_TEXT'];
 
-      let alert = this.alertCtrl.create({
+      const alert = this.alertCtrl.create({
         message,
         buttons: [{
           text: 'Ok'
@@ -126,9 +128,9 @@ export class SettingsPage implements OnInit, OnDestroy {
   }
 
   private showBackup(keys: WalletKeys) {
-    if (!keys) return;
+    if (!keys) { return; }
 
-    let modal = this.modalCtrl.create('WalletBackupModal', {
+    const modal = this.modalCtrl.create('WalletBackupModal', {
       title: 'SETTINGS_PAGE.WALLET_BACKUP',
       keys,
     });

--- a/src/pages/transaction/transaction-response/transaction-response.ts
+++ b/src/pages/transaction/transaction-response/transaction-response.ts
@@ -24,7 +24,7 @@ export class TransactionResponsePage {
   public keys: WalletKeys = {};
   public response: any = { status: false, message: '' };
 
-  public showKeepSecondPassphrase: boolean = true;
+  public showKeepSecondPassphrase = true;
   public currentNetwork: Network;
 
   constructor(
@@ -41,12 +41,12 @@ export class TransactionResponsePage {
     this.response = this.navParams.get('response');
     this.keys = this.navParams.get('keys');
 
-    let transaction = this.navParams.get('transaction');
+    const transaction = this.navParams.get('transaction');
 
-    if (!this.response) this.navCtrl.pop();
+    if (!this.response) { this.navCtrl.pop(); }
 
     this.currentNetwork = this.userDataProvider.currentNetwork;
-    if (transaction) this.transaction = new Transaction(this.wallet.address).deserialize(transaction);
+    if (transaction) { this.transaction = new Transaction(this.wallet.address).deserialize(transaction); }
 
     this.verifySecondPassphrasHasEncrypted();
   }
@@ -58,7 +58,7 @@ export class TransactionResponsePage {
   }
 
   openInExplorer() {
-    let url = `${this.currentNetwork.explorer}/tx/${this.transaction.id}`;
+    const url = `${this.currentNetwork.explorer}/tx/${this.transaction.id}`;
     return this.iab.create(url);
   }
 
@@ -67,20 +67,20 @@ export class TransactionResponsePage {
   }
 
   saveSecondPassphrase() {
-    let modal = this.modalCtrl.create('PinCodeModal', {
+    const modal = this.modalCtrl.create('PinCodeModal', {
       message: 'PIN_CODE.TYPE_PIN_ENCRYPT_PASSPHRASE',
       outputPassword: true,
       validatePassword: true,
     });
 
     modal.onDidDismiss((password) => {
-      if (!password) return;
+      if (!password) { return; }
 
       this.userDataProvider.encryptSecondPassphrase(this.wallet, password, this.keys.secondPassphrase).subscribe(() => {
         this.wallet = this.userDataProvider.getWalletByAddress(this.wallet.address);
 
         this.showKeepSecondPassphrase = false;
-        if (this.content) this.content.resize();
+        if (this.content) { this.content.resize(); }
         this.presentEncryptedAlert();
       });
     });
@@ -89,14 +89,14 @@ export class TransactionResponsePage {
   }
 
   verifySecondPassphrasHasEncrypted() {
-    if (!this.transaction) return;
+    if (!this.transaction) { return; }
 
     if (this.transaction.type === TransactionType.SecondSignature || (this.wallet.secondSignature && !this.wallet.cipherSecondKey)) {
-      if (this.response.status) return this.showKeepSecondPassphrase = true;
+      if (this.response.status) { return this.showKeepSecondPassphrase = true; }
     }
 
     this.showKeepSecondPassphrase = false;
-    if (this.content) this.content.resize();
+    if (this.content) { this.content.resize(); }
   }
 
   dismiss() {

--- a/src/pages/transaction/transaction-send/transaction-send.ts
+++ b/src/pages/transaction/transaction-send/transaction-send.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
-import { FormGroup, Validators, FormControl } from '@angular/forms'
+import { FormGroup, Validators, FormControl } from '@angular/forms';
 
 import { Contact, Wallet, MarketTicker, MarketCurrency, SendTransactionForm, WalletKeys } from '@models/model';
 
@@ -23,10 +23,10 @@ import * as constants from '@app/app.constants';
 import { TransactionSend } from 'ark-ts';
 
 import { AutoCompleteComponent } from 'ionic2-auto-complete';
-import { AutoCompleteContact } from "@models/contact";
-import { TranslatableObject } from "@models/translate";
+import { AutoCompleteContact } from '@models/contact';
+import { TranslatableObject } from '@models/translate';
 import { BigNumber } from 'bignumber.js';
-import { ArkUtility } from "../../../utils/ark-utility";
+import { ArkUtility } from '../../../utils/ark-utility';
 
 @IonicPage()
 @Component({
@@ -49,10 +49,10 @@ export class TransactionSendPage implements OnInit {
   marketTicker: MarketTicker;
   marketCurrency: MarketCurrency;
   fees: Fees;
-  isExistingContact: boolean = true;
+  isExistingContact = true;
   isRecipientNameAutoSet: boolean;
 
-  tokenPlaceholder: number = 100;
+  tokenPlaceholder = 100;
   fiatPlaceholder: number;
 
   private currentAutoCompleteFieldValue: string;
@@ -115,7 +115,7 @@ export class TransactionSendPage implements OnInit {
     this.isRecipientNameAutoSet = true;
 
     // if we have a real contact or a wallet with a label, we don't show the field to add a new contact
-    if (contact.name != contact.address) {
+    if (contact.name !== contact.address) {
       this.isExistingContact = true;
       this.transaction.recipientName = contact.name;
     } else {
@@ -127,7 +127,7 @@ export class TransactionSendPage implements OnInit {
   public onSearchInput(input: string): void {
     // this check is needed because clicking into the field, also triggers this method
     // an then the recipientName is set to null, even though nothing has changed
-    if (input == this.currentAutoCompleteFieldValue) {
+    if (input === this.currentAutoCompleteFieldValue) {
       return;
     }
 
@@ -141,7 +141,7 @@ export class TransactionSendPage implements OnInit {
   }
 
   private validAddress(): boolean {
-    let isValid = PublicKey.validateAddress(this.transaction.recipientAddress, this.currentNetwork);
+    const isValid = PublicKey.validateAddress(this.transaction.recipientAddress, this.currentNetwork);
     this.sendTransactionHTMLForm.form.controls['recipientAddress'].setErrors({ incorrect: !isValid });
 
     return isValid;
@@ -149,11 +149,11 @@ export class TransactionSendPage implements OnInit {
 
   private validForm(): boolean {
     let isValid: boolean;
-    for (let name in this.sendTransactionHTMLForm.form.controls) {
+    for (const name in this.sendTransactionHTMLForm.form.controls) {
       if (name === 'recipientAddress') {
         continue;
       }
-      let control = this.sendTransactionHTMLForm.form.controls[name];
+      const control = this.sendTransactionHTMLForm.form.controls[name];
       isValid = control.valid;
       if (!isValid) {
         break;
@@ -168,13 +168,13 @@ export class TransactionSendPage implements OnInit {
       return;
     }
 
-    let validAddress = this.validAddress();
+    const validAddress = this.validAddress();
     let validName = !!this.transaction.recipientName;
     if (validName) {
       validName = new RegExp('^[a-zA-Z0-9]+[a-zA-Z0-9- ]+$').test(this.transaction.recipientName);
     }
     if (validAddress && validName) {
-      let contact = new Contact();
+      const contact = new Contact();
       contact.name = this.transaction.recipientName;
       this.userDataProvider.addContact(this.transaction.recipientAddress, contact);
     }
@@ -185,7 +185,7 @@ export class TransactionSendPage implements OnInit {
   }
 
   onInputToken() {
-    let precision = this.marketCurrency.code === 'btc' ? 8 : 2;
+    const precision = this.marketCurrency.code === 'btc' ? 8 : 2;
     this.transaction.amountEquivalent = +(this.transaction.amount * this.marketCurrency.price).toFixed(precision);
   }
 
@@ -194,8 +194,8 @@ export class TransactionSendPage implements OnInit {
   }
 
   onEnterPinCode(keys: WalletKeys) {
-    let amount = new BigNumber(this.transaction.amount)
-    let data: TransactionSend = {
+    const amount = new BigNumber(this.transaction.amount);
+    const data: TransactionSend = {
       amount: amount.times(constants.WALLET_UNIT_TO_SATOSHI).toNumber(),
       vendorField: this.transaction.smartBridge,
       passphrase: keys.key,
@@ -227,8 +227,8 @@ export class TransactionSendPage implements OnInit {
       this.settingsDataProvider.settings.subscribe((settings) => {
         this.marketCurrency = ticker.getCurrency({ code: settings.currency });
         this.fiatPlaceholder = +(this.tokenPlaceholder * this.marketCurrency.price).toFixed(2);
-      })
-    })
+      });
+    });
   }
 
   ngOnInit(): void {

--- a/src/pages/transaction/transaction-show/transaction-show.ts
+++ b/src/pages/transaction/transaction-show/transaction-show.ts
@@ -19,10 +19,10 @@ export class TransactionShowPage {
 
   public transaction: Transaction;
   public currentNetwork: Network;
-  public equivalentAmount: number = 0;
+  public equivalentAmount = 0;
   public equivalentSymbol: string;
 
-  public showOptions: boolean = false;
+  public showOptions = false;
 
   private currentWallet: Wallet;
 
@@ -33,38 +33,38 @@ export class TransactionShowPage {
     private inAppBrowser: InAppBrowser,
     private actionSheetCtrl: ActionSheetController,
     private translateService: TranslateService,
-    private TruncateMiddlePipe: TruncateMiddlePipe,
+    private truncateMiddlePipe: TruncateMiddlePipe,
     private platform: Platform,
   ) {
-    let transaction = this.navParams.get('transaction');
+    const transaction = this.navParams.get('transaction');
     this.currentNetwork = this.userDataProvider.currentNetwork;
     this.currentWallet = this.userDataProvider.currentWallet;
 
     this.equivalentAmount = this.navParams.get('equivalentAmount');
     this.equivalentSymbol = this.navParams.get('equivalentSymbol');
 
-    if (!transaction) this.navCtrl.popToRoot();
+    if (!transaction) { this.navCtrl.popToRoot(); }
 
     this.transaction = new Transaction(transaction.address).deserialize(transaction);
     this.shouldShowOptions();
   }
 
   openInExplorer() {
-    let url = `${this.currentNetwork.explorer}/tx/${this.transaction.id}`;
+    const url = `${this.currentNetwork.explorer}/tx/${this.transaction.id}`;
     return this.inAppBrowser.create(url, '_system');
   }
 
   presentOptions() {
-    let address = this.transaction.getAppropriateAddress();
-    let addressTruncated = this.TruncateMiddlePipe.transform(address, 10, null);
-    let contact = this.userDataProvider.getContactByAddress(address);
-    let contactOrAddress = contact ? contact['name'] : addressTruncated;
+    const address = this.transaction.getAppropriateAddress();
+    const addressTruncated = this.truncateMiddlePipe.transform(address, 10, null);
+    const contact = this.userDataProvider.getContactByAddress(address);
+    const contactOrAddress = contact ? contact['name'] : addressTruncated;
 
     this.translateService.get([
       'TRANSACTIONS_PAGE.ADD_ADDRESS_TO_CONTACTS',
       'TRANSACTIONS_PAGE.SEND_TOKEN_TO_ADDRESS',
     ], { address: contactOrAddress, token: this.currentNetwork.token }).subscribe((translation) => {
-      let buttons = [];
+      const buttons = [];
 
       if (!contact) {
         buttons.push({
@@ -85,7 +85,7 @@ export class TransactionShowPage {
           handler: () => {
             this.sendToAddress(address);
           }
-        })
+        });
       }
 
       this.actionSheetCtrl.create({ buttons }).present();
@@ -97,13 +97,13 @@ export class TransactionShowPage {
   }
 
   sendToAddress(address: string) {
-    this.navCtrl.push('TransactionSendPage', { address })
+    this.navCtrl.push('TransactionSendPage', { address });
   }
 
   private shouldShowOptions() {
     if (this.transaction.isTransfer()) {
-      let contact = this.userDataProvider.getContactByAddress(this.transaction.getAppropriateAddress());
-      if (!contact || !this.currentWallet.isWatchOnly) return this.showOptions = true;
+      const contact = this.userDataProvider.getContactByAddress(this.transaction.getAppropriateAddress());
+      if (!contact || !this.currentWallet.isWatchOnly) { return this.showOptions = true; }
     }
   }
 

--- a/src/pages/wallet/wallet-dashboard/modal/register-delegate/register-delegate.ts
+++ b/src/pages/wallet/wallet-dashboard/modal/register-delegate/register-delegate.ts
@@ -17,7 +17,7 @@ export class RegisterDelegatePage implements OnDestroy {
   public name: string;
 
   public allowedDelegateNameChars = '[a-z0-9!@$&_.]+';
-  public isExists: boolean = false;
+  public isExists = false;
 
   private delegates;
   private unsubscriber$: Subject<void> = new Subject<void>();
@@ -36,7 +36,7 @@ export class RegisterDelegatePage implements OnDestroy {
 
   validateName() {
     this.name = this.name.toLowerCase();
-    let find = lodash.find(this.delegates, { username: this.name.trim() });
+    const find = lodash.find(this.delegates, { username: this.name.trim() });
 
     this.isExists = !lodash.isNil(find);
   }

--- a/src/pages/wallet/wallet-dashboard/modal/register-second-passphrase/register-second-passphrase.ts
+++ b/src/pages/wallet/wallet-dashboard/modal/register-second-passphrase/register-second-passphrase.ts
@@ -18,8 +18,8 @@ export class RegisterSecondPassphrasePage {
   public fees: Fees;
   public currentNetwork: Network;
 
-  public step: number = 1;
-  public isWrong: boolean = false;
+  public step = 1;
+  public isWrong = false;
 
   constructor(
     public navCtrl: NavController,

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -1,8 +1,20 @@
 import {Component, NgZone, OnDestroy, ViewChild} from '@angular/core';
-import { IonicPage, NavController, NavParams, Platform, ActionSheetController, ModalController, AlertController, LoadingController, Loading, Content } from 'ionic-angular';
+import {
+  IonicPage,
+  NavController,
+  NavParams,
+  Platform,
+  ActionSheetController,
+  ModalController,
+  AlertController,
+  LoadingController,
+  Loading,
+  Content
+} from 'ionic-angular';
 
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/takeUntil';
+import 'rxjs/add/operator/finally';
 
 import { Profile, Wallet, Transaction, MarketTicker, MarketCurrency, MarketHistory, WalletKeys } from '@models/model';
 import { UserDataProvider } from '@providers/user-data/user-data';
@@ -47,7 +59,7 @@ export class WalletDashboardPage implements OnDestroy {
   private newDelegateName: string;
   private newSecondPassphrase: string;
 
-  public emptyTransactions: boolean = false;
+  public emptyTransactions = false;
   public minConfirmations = constants.WALLET_MIN_NUMBER_CONFIRMATIONS;
 
   private unsubscriber$: Subject<void> = new Subject<void>();
@@ -74,7 +86,7 @@ export class WalletDashboardPage implements OnDestroy {
   ) {
     this.address = this.navParams.get('address');
 
-    if (!this.address) this.navCtrl.popToRoot();
+    if (!this.address) { this.navCtrl.popToRoot(); }
 
     this.profile = this.userDataProvider.currentProfile;
     this.network = this.userDataProvider.currentNetwork;
@@ -94,7 +106,7 @@ export class WalletDashboardPage implements OnDestroy {
       'SETTINGS_PAGE.WALLET_BACKUP',
       'WALLETS_PAGE.REMOVE_WALLET',
     ]).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let delegateItem =  {
+      const delegateItem =  {
         text: translation['DELEGATES_PAGE.REGISTER_DELEGATE'],
         role: 'delegate',
         icon: !this.platform.is('ios') ? 'ios-contact-outline' : '',
@@ -103,7 +115,7 @@ export class WalletDashboardPage implements OnDestroy {
         },
       };
 
-      let delegatesItem = {
+      const delegatesItem = {
           text: translation['DELEGATES_PAGE.DELEGATES'],
           role: 'label',
           icon: !this.platform.is('ios') ? 'ios-people-outline' : '',
@@ -112,7 +124,7 @@ export class WalletDashboardPage implements OnDestroy {
           },
       };
 
-      let buttons = [
+      const buttons = [
         {
           text: translation['WALLETS_PAGE.LABEL'],
           role: 'label',
@@ -130,7 +142,7 @@ export class WalletDashboardPage implements OnDestroy {
         }
       ];
 
-      let backupItem = {
+      const backupItem = {
         text: translation['SETTINGS_PAGE.WALLET_BACKUP'],
         role: 'label',
         icon: !this.platform.is('ios') ? 'ios-briefcase-outline' : '',
@@ -141,11 +153,11 @@ export class WalletDashboardPage implements OnDestroy {
 
       // DEPRECATED:
       // if (!this.wallet.isWatchOnly && !this.wallet.secondSignature) buttons.unshift(secondPassphraseItem);
-      if (!this.wallet.isWatchOnly) buttons.unshift(delegatesItem); // "Watch Only" address can't vote
-      if (!this.wallet.isWatchOnly && !this.wallet.isDelegate) buttons.unshift(delegateItem);
-      if (!this.wallet.isWatchOnly) buttons.splice(buttons.length - 1, 0, backupItem);
+      if (!this.wallet.isWatchOnly) { buttons.unshift(delegatesItem); } // "Watch Only" address can't vote
+      if (!this.wallet.isWatchOnly && !this.wallet.isDelegate) { buttons.unshift(delegateItem); }
+      if (!this.wallet.isWatchOnly) { buttons.splice(buttons.length - 1, 0, backupItem); }
 
-      let action = this.actionSheetCtrl.create({buttons});
+      const action = this.actionSheetCtrl.create({buttons});
 
       action.present();
     });
@@ -157,9 +169,9 @@ export class WalletDashboardPage implements OnDestroy {
   }
 
   private showBackup(keys: WalletKeys) {
-    if (!keys) return;
+    if (!keys) { return; }
 
-    let modal = this.modalCtrl.create('WalletBackupModal', {
+    const modal = this.modalCtrl.create('WalletBackupModal', {
       title: 'SETTINGS_PAGE.WALLET_BACKUP',
       keys,
     });
@@ -168,33 +180,35 @@ export class WalletDashboardPage implements OnDestroy {
   }
 
   presentAddActionSheet() {
-    this.translateService.get(['TRANSACTIONS_PAGE.SEND', 'TRANSACTIONS_PAGE.RECEIVE']).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let buttons: Array<object> = [
-        {
-          text: translation['TRANSACTIONS_PAGE.RECEIVE'],
-          role: 'receive',
-          icon: !this.platform.is('ios') ? 'ios-arrow-round-down' : '',
-          handler: () => {
-            return this.openTransactionReceive();
+    this.translateService.get(['TRANSACTIONS_PAGE.SEND', 'TRANSACTIONS_PAGE.RECEIVE'])
+      .takeUntil(this.unsubscriber$)
+      .subscribe((translation) => {
+        const buttons: Array<object> = [
+          {
+            text: translation['TRANSACTIONS_PAGE.RECEIVE'],
+            role: 'receive',
+            icon: !this.platform.is('ios') ? 'ios-arrow-round-down' : '',
+            handler: () => {
+              return this.openTransactionReceive();
+            }
           }
+        ];
+        if (!this.wallet.isWatchOnly) {
+          buttons.push({
+            text: translation['TRANSACTIONS_PAGE.SEND'],
+            role: 'send',
+            icon: !this.platform.is('ios') ? 'ios-arrow-round-up' : '',
+            handler: () => {
+              return this.navCtrl.push('TransactionSendPage');
+            }
+          });
         }
-      ];
-      if (!this.wallet.isWatchOnly) {
-        buttons.push({
-          text: translation['TRANSACTIONS_PAGE.SEND'],
-          role: 'send',
-          icon: !this.platform.is('ios') ? 'ios-arrow-round-up' : '',
-          handler: () => {
-            return this.navCtrl.push('TransactionSendPage');
-          }
+
+        const action = this.actionSheetCtrl.create({
+          buttons: buttons
         });
-      }
 
-      let action = this.actionSheetCtrl.create({
-        buttons: buttons
-      });
-
-      action.present();
+        action.present();
     });
   }
 
@@ -219,10 +233,10 @@ export class WalletDashboardPage implements OnDestroy {
   }
 
   presentLabelModal() {
-    let modal = this.modalCtrl.create('SetLabelPage', {'label': this.wallet.label }, { cssClass: 'inset-modal-tiny' });
+    const modal = this.modalCtrl.create('SetLabelPage', {'label': this.wallet.label }, { cssClass: 'inset-modal-tiny' });
 
     modal.onDidDismiss((data) => {
-      if (lodash.isEmpty(data)) return;
+      if (lodash.isEmpty(data)) { return; }
 
       this.zone.run(() => this.wallet.label = data);
       this.saveWallet();
@@ -232,10 +246,10 @@ export class WalletDashboardPage implements OnDestroy {
   }
 
   presentRegisterDelegateModal() {
-    let modal = this.modalCtrl.create('RegisterDelegatePage', null, { cssClass: 'inset-modal' });
+    const modal = this.modalCtrl.create('RegisterDelegatePage', null, { cssClass: 'inset-modal' });
 
     modal.onDidDismiss((name) => {
-      if (lodash.isEmpty(name)) return;
+      if (lodash.isEmpty(name)) { return; }
 
       this.newDelegateName = name;
       this.onEnterPinCode = this.createDelegate;
@@ -247,10 +261,10 @@ export class WalletDashboardPage implements OnDestroy {
   }
 
   presentRegisterSecondPassphraseModal() {
-    let modal = this.modalCtrl.create('RegisterSecondPassphrasePage', null, { cssClass: 'inset-modal-large'});
+    const modal = this.modalCtrl.create('RegisterSecondPassphrasePage', null, { cssClass: 'inset-modal-large'});
 
     modal.onDidDismiss((newSecondPassphrase) => {
-      if (lodash.isEmpty(newSecondPassphrase)) return;
+      if (lodash.isEmpty(newSecondPassphrase)) { return; }
 
       this.newSecondPassphrase = newSecondPassphrase;
       this.onEnterPinCode = this.createSignature;
@@ -262,30 +276,32 @@ export class WalletDashboardPage implements OnDestroy {
   }
 
   presentDeleteWalletConfirm() {
-    this.translateService.get(['ARE_YOU_SURE', 'CONFIRM', 'CANCEL', 'WALLETS_PAGE.REMOVE_WALLET_TEXT']).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let confirm = this.alertCtrl.create({
-        title: translation.ARE_YOU_SURE,
-        message: translation['WALLETS_PAGE.REMOVE_WALLET_TEXT'],
-        buttons: [
-          {
-            text: translation.CANCEL
-          },
-          {
-            text: translation.CONFIRM,
-            handler: () => {
-              this.deleteWallet();
+    this.translateService.get(['ARE_YOU_SURE', 'CONFIRM', 'CANCEL', 'WALLETS_PAGE.REMOVE_WALLET_TEXT'])
+      .takeUntil(this.unsubscriber$)
+      .subscribe((translation) => {
+        const confirm = this.alertCtrl.create({
+          title: translation.ARE_YOU_SURE,
+          message: translation['WALLETS_PAGE.REMOVE_WALLET_TEXT'],
+          buttons: [
+            {
+              text: translation.CANCEL
+            },
+            {
+              text: translation.CONFIRM,
+              handler: () => {
+                this.deleteWallet();
+              }
             }
-          }
-        ]
-      });
-      confirm.present();
+          ]
+        });
+        confirm.present();
     });
   }
 
   private createDelegate(keys: WalletKeys) {
-    let publicKey = this.wallet.publicKey || PrivateKey.fromSeed(keys.key).getPublicKey().toHex();
+    const publicKey = this.wallet.publicKey || PrivateKey.fromSeed(keys.key).getPublicKey().toHex();
 
-    let transaction = <TransactionDelegate>{
+    const transaction = <TransactionDelegate>{
       passphrase: keys.key,
       secondPassphrase: keys.secondKey,
       username: this.newDelegateName,
@@ -327,7 +343,7 @@ export class WalletDashboardPage implements OnDestroy {
         orderBy: 'timestamp:desc',
       })
       .finally(() => this.zone.run(() => {
-        if (loader) loader.dismiss();
+        if (loader) { loader.dismiss(); }
         this.emptyTransactions = lodash.isEmpty(this.wallet.transactions);
       }))
       .takeUntil(this.unsubscriber$)
@@ -336,7 +352,7 @@ export class WalletDashboardPage implements OnDestroy {
           this.wallet.loadTransactions(response.transactions);
           this.wallet.lastUpdate = new Date().getTime();
           this.wallet.isCold = lodash.isEmpty(response.transactions);
-          if (save) this.saveWallet();
+          if (save) { this.saveWallet(); }
         }
       });
     });
@@ -350,7 +366,7 @@ export class WalletDashboardPage implements OnDestroy {
     this.arkApiProvider.api.account.get({ address: this.address }).takeUntil(this.unsubscriber$).subscribe((response) => {
       if (response.success) {
         this.wallet.deserialize(response.account);
-        if (save) this.saveWallet();
+        if (save) { this.saveWallet(); }
       }
     });
   }
@@ -377,7 +393,7 @@ export class WalletDashboardPage implements OnDestroy {
       .takeUntil(this.unsubscriber$)
       .debounceTime(500)
       .subscribe((wallet) => {
-        if (!lodash.isEmpty(wallet) && this.wallet.address == wallet.address) this.wallet = wallet;
+        if (!lodash.isEmpty(wallet) && this.wallet.address === wallet.address) { this.wallet = wallet; }
       });
   }
 
@@ -394,13 +410,13 @@ export class WalletDashboardPage implements OnDestroy {
 
     this.userDataProvider.setCurrentWallet(this.wallet);
 
-    let transactions = this.wallet.transactions;
+    const transactions = this.wallet.transactions;
     this.emptyTransactions = lodash.isEmpty(transactions);
 
     // search for new transactions immediately
     if (this.emptyTransactions && !this.wallet.isCold) {
       this.translateService.get('TRANSACTIONS_PAGE.FETCHING_TRANSACTIONS').takeUntil(this.unsubscriber$).subscribe((translation) => {
-        let loader = this.loadingCtrl.create({
+        const loader = this.loadingCtrl.create({
           content: `${translation}...`,
         });
 

--- a/src/pages/wallet/wallet-import-passphrase/wallet-import-passphrase.ts
+++ b/src/pages/wallet/wallet-import-passphrase/wallet-import-passphrase.ts
@@ -17,7 +17,7 @@ export class WalletImportPassphrasePage {
 
   public currentProfile: Profile;
   public currentNetwork: Network;
-  public passphrase: string = '';
+  public passphrase = '';
 
   constructor(
     public navCtrl: NavController,
@@ -34,16 +34,16 @@ export class WalletImportPassphrasePage {
   }
 
   submitForm() {
-    let privateKey = PrivateKey.fromSeed(this.passphrase, this.currentNetwork);
-    let publicKey = privateKey.getPublicKey();
-    let address = publicKey.getAddress();
+    const privateKey = PrivateKey.fromSeed(this.passphrase, this.currentNetwork);
+    const publicKey = privateKey.getPublicKey();
+    const address = publicKey.getAddress();
 
     let newWallet = new Wallet();
 
     this.arkApiProvider.api.account
       .get({ address })
       .finally(() => {
-        let modal = this.modalCtrl.create('PinCodeModal', {
+        const modal = this.modalCtrl.create('PinCodeModal', {
           message: 'PIN_CODE.TYPE_PIN_ENCRYPT_PASSPHRASE',
           outputPassword: true,
           validatePassword: true,
@@ -60,7 +60,7 @@ export class WalletImportPassphrasePage {
                 });
             });
           } else {
-            this.toastProvider.error('WALLETS_PAGE.ADD_WALLET_ERROR')
+            this.toastProvider.error('WALLETS_PAGE.ADD_WALLET_ERROR');
           }
 
         });
@@ -69,7 +69,7 @@ export class WalletImportPassphrasePage {
       })
       .subscribe((response) => {
         if (response && response.success) {
-          let account = response.account;
+          const account = response.account;
 
           newWallet = newWallet.deserialize(account);
         } else {

--- a/src/pages/wallet/wallet-import/wallet-import.ts
+++ b/src/pages/wallet/wallet-import/wallet-import.ts
@@ -41,7 +41,7 @@ export class WalletImportPage {
       let privateKey = null;
       let publicKey = null;
       let address = qrCode.address || null;
-      let passphrase = qrCode.passphrase || null;
+      const passphrase = qrCode.passphrase || null;
       if (address) {
         if (PublicKey.validateAddress(address, this.currentNetwork)) {
           publicKey = PublicKey.fromAddress(address);
@@ -55,14 +55,14 @@ export class WalletImportPage {
         address = publicKey.getAddress();
       }
 
-      if (!publicKey) return;
+      if (!publicKey) { return; }
 
       let newWallet = new Wallet(!privateKey);
       this.arkApiProvider.api.account
         .get({ address })
         .finally(() => {
           if (privateKey) {
-            let modal = this.modalCtrl.create('PinCodeModal', {
+            const modal = this.modalCtrl.create('PinCodeModal', {
               message: 'PIN_CODE.TYPE_PIN_ENCRYPT_PASSPHRASE',
               outputPassword: true,
               validatePassword: true,
@@ -95,7 +95,7 @@ export class WalletImportPage {
         })
         .subscribe((response) => {
           if (response && response.success) {
-            let account = response.account;
+            const account = response.account;
 
             newWallet = newWallet.deserialize(account);
           } else {

--- a/src/pages/wallet/wallet-list/wallet-list.ts
+++ b/src/pages/wallet/wallet-list/wallet-list.ts
@@ -23,7 +23,7 @@ import { BaseChartDirective } from 'ng2-charts';
   selector: 'page-wallet-list',
   templateUrl: 'wallet-list.html',
 })
-export class WalletListPage implements OnDestroy{
+export class WalletListPage implements OnDestroy {
   @ViewChild('walletSlider') slider: Slides;
   @ViewChild(Content) content: Content;
   @ViewChild('chart') chart: BaseChartDirective;
@@ -87,7 +87,7 @@ export class WalletListPage implements OnDestroy{
       'GENERATE',
       'IMPORT',
     ]).takeUntil(this.unsubscriber$).subscribe((translation) => {
-      let actionSheet = this.actionSheetCtrl.create({
+      const actionSheet = this.actionSheetCtrl.create({
         buttons: [
           {
             text: translation.GENERATE,
@@ -112,18 +112,18 @@ export class WalletListPage implements OnDestroy{
   }
 
   private presentWalletGenerate() {
-    let modal = this.modalCtrl.create('GenerateEntropyModal');
+    const modal = this.modalCtrl.create('GenerateEntropyModal');
 
     modal.onDidDismiss((entropy) => {
-      if (!entropy) return;
+      if (!entropy) { return; }
 
-      let showModal = this.modalCtrl.create('WalletBackupModal', {
+      const showModal = this.modalCtrl.create('WalletBackupModal', {
         title: 'WALLETS_PAGE.CREATE_WALLET',
         entropy,
       });
 
       showModal.onDidDismiss((account) => {
-        if (!account) return;
+        if (!account) { return; }
 
         this.storeWallet(account);
       });
@@ -140,18 +140,18 @@ export class WalletListPage implements OnDestroy{
   }
 
   private storeWallet(account) {
-    let wallet = new Wallet();
+    const wallet = new Wallet();
     wallet.address = account.address;
     wallet.publicKey = account.publicKey;
 
-    let modal = this.modalCtrl.create('PinCodeModal', {
+    const modal = this.modalCtrl.create('PinCodeModal', {
       message: 'PIN_CODE.TYPE_PIN_ENCRYPT_PASSPHRASE',
       outputPassword: true,
       validatePassword: true
     });
 
     modal.onDidDismiss((password) => {
-      if (!password) return;
+      if (!password) { return; }
 
       this.userDataProvider.addWallet(wallet, account.mnemonic, password).takeUntil(this.unsubscriber$).subscribe(() => {
         this.loadWallets();
@@ -163,18 +163,18 @@ export class WalletListPage implements OnDestroy{
 
   private loadWallets() {
     this.loadUserData();
-    if (!this.currentProfile || lodash.isEmpty(this.currentProfile.wallets)) return;
+    if (!this.currentProfile || lodash.isEmpty(this.currentProfile.wallets)) { return; }
 
-    let list = [];
-    for (let w of lodash.values(this.currentProfile.wallets)) {
-      let wallet = new Wallet().deserialize(w);
+    const list = [];
+    for (const w of lodash.values(this.currentProfile.wallets)) {
+      const wallet = new Wallet().deserialize(w);
       if (PublicKey.validateAddress(wallet.address, this.currentNetwork)) {
         list.push(wallet);
       }
     }
 
     this.totalBalance = lodash(list).values().sumBy((w) => parseInt(w.balance));
-    let wholeArk = (this.totalBalance / constants.WALLET_UNIT_TO_SATOSHI);
+    const wholeArk = (this.totalBalance / constants.WALLET_UNIT_TO_SATOSHI);
     this.fiatBalance = wholeArk * (this.fiatCurrency ? this.fiatCurrency.price : 0);
 
     this.wallets = lodash.orderBy(list, ['lastUpdate'], ['desc']);
@@ -207,28 +207,28 @@ export class WalletListPage implements OnDestroy{
       'WEEK_DAY.FRIDAY',
       'WEEK_DAY.SATURDAY',
     ]).subscribe((translation) => {
-      if (lodash.isEmpty(this.wallets)) return;
+      if (lodash.isEmpty(this.wallets)) { return; }
 
-      let days = lodash.values(translation);
+      const days = lodash.values(translation);
 
       this.settingsDataProvider.settings.subscribe((settings) => {
         this.marketDataProvider.history.subscribe();
         this.marketDataProvider.onUpdateHistory$.takeUntil(this.unsubscriber$).subscribe((history) => {
-          if (!history) return;
+          if (!history) { return; }
 
-          let currency = (!settings || !settings.currency) ? this.settingsDataProvider.getDefaults().currency : settings.currency;
+          const currency = (!settings || !settings.currency) ? this.settingsDataProvider.getDefaults().currency : settings.currency;
 
-          let fiatHistory = history.getLastWeekPrice(currency.toUpperCase());
-          let btcHistory = history.getLastWeekPrice('BTC');
+          const fiatHistory = history.getLastWeekPrice(currency.toUpperCase());
+          const btcHistory = history.getLastWeekPrice('BTC');
 
           this.chartLabels = null;
 
           this.chartData = [{
-            yAxisID : "A",
+            yAxisID : 'A',
             fill: false,
             data: fiatHistory.prices,
           }, {
-            yAxisID : "B",
+            yAxisID : 'B',
             fill: false,
             data: btcHistory.prices,
           }];
@@ -295,7 +295,7 @@ export class WalletListPage implements OnDestroy{
     this.btcCurrency = ticker.getCurrency({ code: 'btc' });
 
     this.settingsDataProvider.settings.subscribe((settings) => {
-      let currency = (!settings || !settings.currency) ? this.settingsDataProvider.getDefaults().currency : settings.currency;
+      const currency = (!settings || !settings.currency) ? this.settingsDataProvider.getDefaults().currency : settings.currency;
 
       this.fiatCurrency = ticker.getCurrency({ code: currency });
       this.loadWallets();
@@ -319,7 +319,7 @@ export class WalletListPage implements OnDestroy{
 
     // Fetch from api or get from storage
     this.marketDataProvider.fetchHistory().subscribe((history) => {
-      this.marketHistory = history
+      this.marketHistory = history;
     }, () => this.marketDataProvider.history.subscribe((history) => this.marketHistory = history));
 
     this.content.resize();

--- a/src/pipes/account-label/account-label.ts
+++ b/src/pipes/account-label/account-label.ts
@@ -11,16 +11,16 @@ export class AccountLabelPipe implements PipeTransform {
   }
 
   transform(value: string, defaultText: string, ...args) {
-    let contact = this.userDataProvider.getContactByAddress(value);
-    if (contact) return contact.name;
+    const contact = this.userDataProvider.getContactByAddress(value);
+    if (contact) { return contact.name; }
 
-    let wallet = this.userDataProvider.getWalletByAddress(value);
+    const wallet = this.userDataProvider.getWalletByAddress(value);
     if (wallet) {
-      let label = wallet.username || wallet.label;
-      if (label) return label;
+      const label = wallet.username || wallet.label;
+      if (label) { return label; }
     }
 
-    if (defaultText) return defaultText;
+    if (defaultText) { return defaultText; }
 
     return value;
   }

--- a/src/pipes/market-number/market-number.ts
+++ b/src/pipes/market-number/market-number.ts
@@ -30,7 +30,7 @@ export class MarketNumberPipe implements PipeTransform, OnDestroy {
   }
 
   private updateCurrency(settings: UserSettings) {
-    if (!this.marketTicker) return;
+    if (!this.marketTicker) { return; }
 
     this.marketCurrency = this.marketTicker.getCurrency({ code: settings.currency });
   }
@@ -40,10 +40,10 @@ export class MarketNumberPipe implements PipeTransform, OnDestroy {
       return;
     }
 
-    let currency = forceCurrency || this.marketCurrency;
-    if (!currency) return;
+    const currency = forceCurrency || this.marketCurrency;
+    if (!currency) { return; }
 
-    let trueValue = new BigNumber(value.toString());
+    const trueValue = new BigNumber(value.toString());
     let decimalPlaces = 2;
 
     if (currency && currency.code === 'btc') {

--- a/src/pipes/pipes.module.ts
+++ b/src/pipes/pipes.module.ts
@@ -7,14 +7,14 @@ import { TimestampHumanPipe } from './timestamp-human/timestamp-human';
 import { TimezonePipe } from './timezone/timezone';
 
 @NgModule({
-	declarations: [TruncateMiddlePipe,
+  declarations: [TruncateMiddlePipe,
     UnitsSatoshiPipe,
     MarketNumberPipe,
     AccountLabelPipe,
     TimestampHumanPipe,
     TimezonePipe],
-	imports: [],
-	exports: [TruncateMiddlePipe,
+  imports: [],
+  exports: [TruncateMiddlePipe,
     UnitsSatoshiPipe,
     MarketNumberPipe,
     AccountLabelPipe,

--- a/src/pipes/timestamp-human/timestamp-human.ts
+++ b/src/pipes/timestamp-human/timestamp-human.ts
@@ -7,7 +7,7 @@ import moment from 'moment';
 })
 export class TimestampHumanPipe implements PipeTransform {
 
-  private language: string = 'en';
+  private language = 'en';
 
   constructor(settingsDataProvider: SettingsDataProvider) {
     settingsDataProvider.settings.subscribe((settings) => this.language = settings.language);

--- a/src/pipes/truncate-middle/truncate-middle.ts
+++ b/src/pipes/truncate-middle/truncate-middle.ts
@@ -6,7 +6,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class TruncateMiddlePipe implements PipeTransform {
 
   transform(value: string, limit: number, originalValue: string, ...args) {
-    if (originalValue && value != originalValue) {
+    if (originalValue && value !== originalValue) {
       return value;
     }
 
@@ -14,9 +14,9 @@ export class TruncateMiddlePipe implements PipeTransform {
       return value;
     }
 
-    let lenghtTruncation = Math.floor((limit - 1) / 2);
-    let leftData = value.slice(0, lenghtTruncation);
-    let rightData = value.slice(value.length - lenghtTruncation);
+    const lenghtTruncation = Math.floor((limit - 1) / 2);
+    const leftData = value.slice(0, lenghtTruncation);
+    const rightData = value.slice(value.length - lenghtTruncation);
 
     return `${leftData}...${rightData}`;
   }

--- a/src/pipes/units-satoshi/units-satoshi.ts
+++ b/src/pipes/units-satoshi/units-satoshi.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { ArkUtility } from "../../utils/ark-utility";
+import { ArkUtility } from '../../utils/ark-utility';
 
 @Pipe({
   name: 'unitsSatoshi',
@@ -7,7 +7,7 @@ import { ArkUtility } from "../../utils/ark-utility";
 export class UnitsSatoshiPipe implements PipeTransform {
 
   transform(value: number | string, returnRaw: boolean = false) {
-    if (typeof value === 'string') value = Number(value);
+    if (typeof value === 'string') { value = Number(value); }
 
     return ArkUtility.arktoshiToArk(value, returnRaw);
   }

--- a/src/providers/ark-api/ark-api.ts
+++ b/src/providers/ark-api/ark-api.ts
@@ -1,20 +1,22 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import 'rxjs/add/operator/expand';
 
 import { UserDataProvider } from '@providers/user-data/user-data';
 import { StorageProvider } from '@providers/storage/storage';
 import { ToastProvider } from '@providers/toast/toast';
 
-let packageJson = require('@root/package.json');
+const packageJson = require('@root/package.json');
 import { Transaction, TranslatableObject } from '@models/model';
 
 import * as arkts from 'ark-ts';
 import lodash from 'lodash';
 import * as constants from '@app/app.constants';
 import arktsConfig from 'ark-ts/config';
-import { ArkUtility } from "../../utils/ark-utility";
+import { ArkUtility } from '../../utils/ark-utility';
 
 @Injectable()
 export class ArkApiProvider {
@@ -40,7 +42,7 @@ export class ArkApiProvider {
     this.loadData();
 
     this.userDataProvider.onActivateNetwork$.subscribe((network) => {
-      if (lodash.isEmpty(network)) return;
+      if (lodash.isEmpty(network)) { return; }
 
       // set default peer
       if (network && !network.activePeer) {
@@ -64,26 +66,26 @@ export class ArkApiProvider {
   }
 
   public get fees() {
-    if (!lodash.isUndefined(this._fees)) return Observable.of(this._fees);
+    if (!lodash.isUndefined(this._fees)) { return Observable.of(this._fees); }
 
     return this.fetchFees();
   }
 
   public get delegates(): Observable<arkts.Delegate[]> {
-    if (!lodash.isEmpty(this._delegates)) return Observable.of(this._delegates);
+    if (!lodash.isEmpty(this._delegates)) { return Observable.of(this._delegates); }
 
-    return this.fetchDelegates(constants.NUM_ACTIVE_DELEGATES*2);
+    return this.fetchDelegates(constants.NUM_ACTIVE_DELEGATES * 2);
   }
 
   public findGoodPeer(): void {
     // Get list from active peer
     this._api.peer.list().subscribe((response) => {
       if (response) {
-        let port = +this._network.activePeer.port;
-        let filteredPeers = lodash.filter(response.peers, (peer) => {
+        const port = +this._network.activePeer.port;
+        const filteredPeers = lodash.filter(response.peers, (peer) => {
           return peer['status'] === 'OK' && peer['port'] === port && peer.ip !== this._network.activePeer.ip && peer.ip !== '127.0.0.1';
         });
-        let sortHeight = lodash.orderBy(filteredPeers, ['height','delay'], ['desc','asc']);
+        const sortHeight = lodash.orderBy(filteredPeers, ['height', 'delay'], ['desc', 'asc']);
         this._peers = sortHeight;
         this.updateNetwork(sortHeight[0]);
       } else {
@@ -101,10 +103,10 @@ export class ArkApiProvider {
   }
 
   public fetchDelegates(numberDelegatesToGet: number, getAllDelegates = false): Observable<arkts.Delegate[]> {
-    if (!this._api) return;
+    if (!this._api) { return; }
     const limit = 51;
 
-    let totalCount = limit;
+    const totalCount = limit;
     let offset, currentPage;
     offset = currentPage = 0;
 
@@ -115,11 +117,11 @@ export class ArkApiProvider {
     return Observable.create((observer) => {
 
       this._api.delegate.list({ limit, offset }).expand(() => {
-        let req = this._api.delegate.list({ limit, offset });
+        const req = this._api.delegate.list({ limit, offset });
         return currentPage < totalPages ? req : Observable.empty();
       }).do((response) => {
         offset += limit;
-        if (response.success && getAllDelegates) numberDelegatesToGet = response.totalCount;
+        if (response.success && getAllDelegates) { numberDelegatesToGet = response.totalCount; }
         totalPages = Math.ceil(numberDelegatesToGet / limit);
         currentPage++;
       }).finally(() => {
@@ -129,7 +131,7 @@ export class ArkApiProvider {
         observer.next(delegates);
         observer.complete();
       }).subscribe((data) => {
-        if (data.success) delegates = [...delegates, ...data.delegates];
+        if (data.success) { delegates = [...delegates, ...data.delegates]; }
       });
     });
 
@@ -137,8 +139,8 @@ export class ArkApiProvider {
 
   public createTransaction(transaction: Transaction, key: string, secondKey: string, secondPassphrase: string): Observable<Transaction> {
     return Observable.create((observer) => {
-      let configNetwork = arktsConfig.networks[this._network.name];
-      let jsNetwork = {
+      const configNetwork = arktsConfig.networks[this._network.name];
+      const jsNetwork = {
         messagePrefix: configNetwork.name,
         bip32: configNetwork.bip32,
         pubKeyHash: configNetwork.version,
@@ -153,7 +155,7 @@ export class ArkApiProvider {
         return observer.complete();
       }
 
-      let wallet = this.userDataProvider.getWalletByAddress(transaction.address);
+      const wallet = this.userDataProvider.getWalletByAddress(transaction.address);
       transaction.senderId = transaction.address;
 
       const totalAmount = transaction.getAmount();
@@ -177,13 +179,13 @@ export class ArkApiProvider {
       transaction.signSignature = null;
       transaction.id = null;
 
-      let keys = this.arkjs.crypto.getKeys(key, jsNetwork);
+      const keys = this.arkjs.crypto.getKeys(key, jsNetwork);
       this.arkjs.crypto.sign(transaction, keys);
 
       secondPassphrase = secondKey || secondPassphrase;
 
       if (secondPassphrase) {
-        let secondKeys = this.arkjs.crypto.getKeys(secondPassphrase, jsNetwork);
+        const secondKeys = this.arkjs.crypto.getKeys(secondPassphrase, jsNetwork);
         this.arkjs.crypto.secondSign(transaction, secondKeys);
       }
 
@@ -202,10 +204,10 @@ export class ArkApiProvider {
       headers = headers.append('port', '1');
       headers = headers.append('nethash', this._network.nethash);
 
-      let url = `http://${peer.ip}:${peer.port}/peer/transactions`;
-      let data = JSON.stringify({ transactions: [transaction] });
-      this.http.post(url, data, { headers }).subscribe((data: arkts.TransactionPostResponse) => {
-        if (data.success) {
+      const url = `http://${peer.ip}:${peer.port}/peer/transactions`;
+      const data = JSON.stringify({ transactions: [transaction] });
+      this.http.post(url, data, { headers }).subscribe((result: arkts.TransactionPostResponse) => {
+        if (result.success) {
           this.onSendTransaction$.next(transaction);
           if (broadcast) {
             this.broadcastTransaction(transaction);
@@ -216,7 +218,7 @@ export class ArkApiProvider {
           if (broadcast) {
             this.toastProvider.error('API.TRANSACTION_FAILED');
           }
-          observer.error(data);
+          observer.error(result);
         }
       }, (error) => observer.error(error));
     });
@@ -224,9 +226,9 @@ export class ArkApiProvider {
   }
 
   private broadcastTransaction(transaction: arkts.Transaction) {
-    let max = 10;
+    const max = 10;
 
-    for (let peer of this._peers.slice(0, max)) {
+    for (const peer of this._peers.slice(0, max)) {
       this.postTransaction(transaction, peer, false).subscribe();
     }
   }
@@ -240,7 +242,7 @@ export class ArkApiProvider {
     this.userDataProvider.updateNetwork(this.userDataProvider.currentProfile.networkId, this._network);
     this._api = new arkts.Client(this._network);
 
-    this.fetchDelegates(constants.NUM_ACTIVE_DELEGATES*2).subscribe((data) => {
+    this.fetchDelegates(constants.NUM_ACTIVE_DELEGATES * 2).subscribe((data) => {
       this._delegates = data;
     });
 
@@ -257,9 +259,9 @@ export class ArkApiProvider {
           observer.next(this._fees);
         }
       }, () => {
-        observer.next(this.storageProvider.getObject(constants.STORAGE_FEES))
+        observer.next(this.storageProvider.getObject(constants.STORAGE_FEES));
       });
-    })
+    });
   }
 
   private loadData() {

--- a/src/providers/auth/auth.ts
+++ b/src/providers/auth/auth.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { StorageProvider } from '@providers/storage/storage';
 
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/takeUntil';
 
@@ -37,7 +38,7 @@ export class AuthProvider {
     this.storage.set(constants.STORAGE_ACTIVE_PROFILE, undefined);
     this.loggedProfileId = undefined;
 
-    if (broadcast) this.onLogout$.next(false);
+    if (broadcast) { this.onLogout$.next(false); }
   }
 
   hasSeenIntro(): Observable<boolean> {
@@ -58,7 +59,7 @@ export class AuthProvider {
   }
 
   saveMasterPassword(password: string): void {
-    let hash = bcrypt.hashSync(password, 8);
+    const hash = bcrypt.hashSync(password, 8);
 
     this.storage.set(constants.STORAGE_MASTERPASSWORD, hash);
   }
@@ -67,7 +68,7 @@ export class AuthProvider {
     return Observable.create((observer) => {
       this.storage.get(constants.STORAGE_MASTERPASSWORD).subscribe((master) => {
         bcrypt.compare(password, master, (err, res) => {
-          if (err) observer.error(err);
+          if (err) { observer.error(err); }
 
           observer.next(res);
           observer.complete();

--- a/src/providers/auto-complete/contacts-service.ts
+++ b/src/providers/auto-complete/contacts-service.ts
@@ -1,11 +1,11 @@
 import { AutoCompleteService } from 'ionic2-auto-complete';
-import { Injectable } from "@angular/core";
-import 'rxjs/add/operator/map'
+import { Injectable } from '@angular/core';
+import 'rxjs/add/operator/map';
 import lodash from 'lodash';
 
 import { UserDataProvider } from '@providers/user-data/user-data';
 import { PublicKey } from 'ark-ts/core';
-import { AutoCompleteContact } from "@models/contact";
+import { AutoCompleteContact } from '@models/contact';
 
 @Injectable()
 export class ContactsAutoCompleteService implements AutoCompleteService {
@@ -25,7 +25,7 @@ export class ContactsAutoCompleteService implements AutoCompleteService {
         return {
           address: key.toString(),
           name: value['name'].toString(),
-          iconName: "ios-contacts-outline"
+          iconName: 'ios-contacts-outline'
         } as AutoCompleteContact;
       }
     });
@@ -37,7 +37,7 @@ export class ContactsAutoCompleteService implements AutoCompleteService {
         return {
           address: address.toString(),
           name: label.toString(),
-          iconName: "ios-cash-outline"
+          iconName: 'ios-cash-outline'
         } as AutoCompleteContact;
       }
     });
@@ -48,11 +48,11 @@ export class ContactsAutoCompleteService implements AutoCompleteService {
   }
 
   private static sortContacts(a: AutoCompleteContact, b: AutoCompleteContact): number {
-    if (a.name != a.address && b.name == b.address) {
+    if (a.name !== a.address && b.name === b.address) {
       return -1;
     }
 
-    if (a.name == a.address && b.name != b.address) {
+    if (a.name === a.address && b.name !== b.address) {
       return 1;
     }
 

--- a/src/providers/forge/forge.ts
+++ b/src/providers/forge/forge.ts
@@ -16,8 +16,8 @@ export class ForgeProvider {
   }
 
   public encrypt(message: string, password: string, address: string, iv: any) {
-    let derivedKey = forge.pkcs5.pbkdf2(password, address, this.interations, this.keySize);
-    let cipher = forge.cipher.createCipher('AES-CBC', derivedKey);
+    const derivedKey = forge.pkcs5.pbkdf2(password, address, this.interations, this.keySize);
+    const cipher = forge.cipher.createCipher('AES-CBC', derivedKey);
     cipher.start({ iv: forge.util.decode64(iv) });
     cipher.update(forge.util.createBuffer(message));
     cipher.finish();
@@ -26,8 +26,8 @@ export class ForgeProvider {
   }
 
   public decrypt(cipherText: string, password: string, address: string, iv: any) {
-    let derivedKey = forge.pkcs5.pbkdf2(password, address, this.interations, this.keySize);
-    let decipher = forge.cipher.createDecipher('AES-CBC', derivedKey);
+    const derivedKey = forge.pkcs5.pbkdf2(password, address, this.interations, this.keySize);
+    const decipher = forge.cipher.createDecipher('AES-CBC', derivedKey);
     decipher.start({ iv: forge.util.decode64(iv) });
     decipher.update(forge.util.createBuffer(forge.util.decode64(cipherText)));
     decipher.finish();

--- a/src/providers/settings-data/settings-data.ts
+++ b/src/providers/settings-data/settings-data.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { StorageProvider } from '@providers/storage/storage';
 
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/takeUntil';
 
@@ -18,31 +19,31 @@ export class SettingsDataProvider {
 
   public AVALIABLE_OPTIONS = {
     languages: {
-      "en": "English",
-      "de": "Deutsch",
-      "it": "Italiano",
-      "nl": "Nederlands",
-      "sv": "Svenska",
-      "ru": "Русский",
-      "gr": "Ελληνικά"
+      'en': 'English',
+      'de': 'Deutsch',
+      'it': 'Italiano',
+      'nl': 'Nederlands',
+      'sv': 'Svenska',
+      'ru': 'Русский',
+      'gr': 'Ελληνικά'
     },
     currencies: {
-      "btc": "Bitcoin",
-      "usd": "Dollar",
-      "eur": "Euro",
-      "gbp": "British Pound",
-      "krw": "South Korean Won",
-      "cny": "Chinese Yuan",
-      "jpy": "Japanese Yen",
-      "aud": "Australian Dollar",
-      "cad": "Canadian Dollar",
-      "rub": "Russian Ruble",
-      "inr": "Indian Rupee",
-      "brl": "Brazilian Real",
-      "chf": "Swiss Franc",
-      "hkd": "Hong Kong Dollar",
-      "idr": "Indonesian Rupiah",
-      "mxn": "Mexican Peso",
+      'btc': 'Bitcoin',
+      'usd': 'Dollar',
+      'eur': 'Euro',
+      'gbp': 'British Pound',
+      'krw': 'South Korean Won',
+      'cny': 'Chinese Yuan',
+      'jpy': 'Japanese Yen',
+      'aud': 'Australian Dollar',
+      'cad': 'Canadian Dollar',
+      'rub': 'Russian Ruble',
+      'inr': 'Indian Rupee',
+      'brl': 'Brazilian Real',
+      'chf': 'Swiss Franc',
+      'hkd': 'Hong Kong Dollar',
+      'idr': 'Indonesian Rupiah',
+      'mxn': 'Mexican Peso',
     },
   };
 
@@ -66,13 +67,13 @@ export class SettingsDataProvider {
   }
 
   public save(options?: UserSettings): Observable<any> {
-    let settings = options || this._settings;
+    const settings = options || this._settings;
 
-    for (let prop in options) {
+    for (const prop in options) {
       this._settings[prop] = settings[prop];
     }
 
-    if (options) this.onUpdate$.next(this._settings);
+    if (options) { this.onUpdate$.next(this._settings); }
     return this._storageProvider.set(constants.STORAGE_SETTINGS, this._settings);
   }
 

--- a/src/providers/storage/storage.ts
+++ b/src/providers/storage/storage.ts
@@ -21,7 +21,7 @@ export class StorageProvider {
   }
 
   public getObject(key) {
-    return Observable.fromPromise(this._storage.get(key)).map((result) => JSON.parse(result || "{}"));
+    return Observable.fromPromise(this._storage.get(key)).map((result) => JSON.parse(result || '{}'));
   }
 
   public set(key, value) {

--- a/src/providers/toast/toast.ts
+++ b/src/providers/toast/toast.ts
@@ -4,7 +4,7 @@ import { ToastController } from 'ionic-angular';
 import { TranslateService } from '@ngx-translate/core';
 
 import * as constants from '@app/app.constants';
-import { TranslatableObject } from "@models/translate";
+import { TranslatableObject } from '@models/translate';
 
 @Injectable()
 export class ToastProvider {
@@ -58,7 +58,7 @@ export class ToastProvider {
   show(messageOrObj: string | TranslatableObject, type?: number, hideDelay?: number, position?: string) {
     let cssClass = 'toast-service';
     if (this.TypeName[type]) {
-      cssClass += ' toast-' + this.TypeName[type]
+      cssClass += ' toast-' + this.TypeName[type];
     }
     let message: string;
     let parameters: any;
@@ -71,7 +71,7 @@ export class ToastProvider {
       parameters = obj.parameters;
     }
     this.translateService.get(message, parameters).subscribe((translation) => {
-      let toast = this.toastCtrl.create({
+      const toast = this.toastCtrl.create({
         message: translation,
         duration: hideDelay || this.hideDelay,
         position: position || this.position,
@@ -79,6 +79,6 @@ export class ToastProvider {
       });
 
       toast.present();
-    })
+    });
   }
 }

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -3,7 +3,8 @@ import { StorageProvider } from '@providers/storage/storage';
 import { AuthProvider } from '@providers/auth/auth';
 import { ForgeProvider } from '@providers/forge/forge';
 
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/map';
 
 import { Contact, Profile, Wallet, WalletKeys } from '@models/model';
@@ -13,7 +14,7 @@ import { v4 as uuid } from 'uuid';
 import { Network } from 'ark-ts/model';
 
 import * as constants from '@app/app.constants';
-import { NetworkType } from "ark-ts";
+import { NetworkType } from 'ark-ts';
 
 @Injectable()
 export class UserDataProvider {
@@ -46,9 +47,9 @@ export class UserDataProvider {
   }
 
   addContact(address: string, contact: Contact, profileId: string = this.authProvider.loggedProfileId) {
-    if (lodash.isNil(this.profiles)) return;
+    if (lodash.isNil(this.profiles)) { return; }
 
-    let contacts = this.profiles[profileId].contacts || {};
+    const contacts = this.profiles[profileId].contacts || {};
     contacts[address] = contact;
 
     this.profiles[profileId]['contacts'] = contacts;
@@ -57,7 +58,7 @@ export class UserDataProvider {
   }
 
   editContact(address: string, contact: Contact) {
-    if (lodash.isNil(this.profiles)) return;
+    if (lodash.isNil(this.profiles)) { return; }
 
     lodash.forEach(this.profiles, (item, id) => {
       if (item['contacts'][address]) {
@@ -69,18 +70,18 @@ export class UserDataProvider {
   }
 
   getContactByAddress(address: string): Contact {
-    if (lodash.isNil(this.profiles) || !address) return;
+    if (lodash.isNil(this.profiles) || !address) { return; }
 
-    let contacts = lodash.map(this.profiles, (p) => p['contacts']);
-    let merged = Object.assign({}, ...contacts);
+    const contacts = lodash.map(this.profiles, (p) => p['contacts']);
+    const merged = Object.assign({}, ...contacts);
 
-    if (lodash.isNil(merged)) return;
+    if (lodash.isNil(merged)) { return; }
 
     return <Contact>merged[address];
   }
 
   removeContactByAddress(address: string) {
-    if (lodash.isNil(this.profiles)) return;
+    if (lodash.isNil(this.profiles)) { return; }
 
     lodash.forEach(this.profiles, (item, id) => {
       this.profiles[id]['contacts'] = lodash.omit(item['contacts'], [address]);
@@ -129,14 +130,17 @@ export class UserDataProvider {
   }
 
   saveProfiles(profiles = this.profiles) {
-    let currentProfile = this.authProvider.loggedProfileId;
+    const currentProfile = this.authProvider.loggedProfileId;
 
-    if (currentProfile) this.setCurrentProfile(currentProfile, false);
+    if (currentProfile) { this.setCurrentProfile(currentProfile, false); }
     return this.storageProvider.set(constants.STORAGE_PROFILES, profiles);
   }
 
-  encryptSecondPassphrase(wallet: Wallet, pinCode: string, secondPassphrase: string, profileId: string = this.authProvider.loggedProfileId) {
-    if (lodash.isUndefined(profileId)) return;
+  encryptSecondPassphrase(wallet: Wallet,
+                          pinCode: string,
+                          secondPassphrase: string,
+                          profileId: string = this.authProvider.loggedProfileId) {
+    if (lodash.isUndefined(profileId)) { return; }
 
     if (wallet && !wallet.cipherSecondKey) {
       // wallet.secondBip38 = this.forgeProvider.encryptBip38(secondWif, pinCode, this.currentNetwork);
@@ -148,15 +152,15 @@ export class UserDataProvider {
   }
 
   addWallet(wallet: Wallet, passphrase: string, pinCode: string, profileId: string = this.authProvider.loggedProfileId) {
-    if (lodash.isUndefined(profileId)) return;
+    if (lodash.isUndefined(profileId)) { return; }
 
-    let profile = this.getProfileById(profileId);
+    const profile = this.getProfileById(profileId);
 
-    let iv = this.forgeProvider.generateIv();
+    const iv = this.forgeProvider.generateIv();
 
     if (passphrase) {
       wallet.iv = iv;
-      let cipherKey = this.forgeProvider.encrypt(passphrase, pinCode, wallet.address, iv);
+      const cipherKey = this.forgeProvider.encrypt(passphrase, pinCode, wallet.address, iv);
       // wallet.bip38 = this.forgeProvider.encryptBip38(wif, pinCode, this.currentNetwork);
       wallet.cipherKey = cipherKey;
     }
@@ -170,19 +174,19 @@ export class UserDataProvider {
   }
 
   updateWalletEncryption(oldPassword: string, newPassword: string) {
-    for (let profileId in this.profiles) {
-      let profile = this.profiles[profileId];
-      for (let walletId in profile.wallets) {
-        let wallet = profile.wallets[walletId];
+    for (const profileId in this.profiles) {
+      const profile = this.profiles[profileId];
+      for (const walletId in profile.wallets) {
+        const wallet = profile.wallets[walletId];
         if (wallet.isWatchOnly) {
           continue;
         }
-        let key = this.forgeProvider.decrypt(wallet.cipherKey, oldPassword, wallet.address, wallet.iv);
+        const key = this.forgeProvider.decrypt(wallet.cipherKey, oldPassword, wallet.address, wallet.iv);
         wallet.cipherKey = this.forgeProvider.encrypt(key, newPassword, wallet.address, wallet.iv);
         // wallet.bip38 = this.forgeProvider.encryptBip38(wif, newPassword, this.currentNetwork);
 
         if (wallet.cipherSecondKey) {
-          let secondKey = this.forgeProvider.decrypt(wallet.cipherSecondKey, oldPassword, wallet.address, wallet.iv);
+          const secondKey = this.forgeProvider.decrypt(wallet.cipherSecondKey, oldPassword, wallet.address, wallet.iv);
           wallet.cipherSecondKey = this.forgeProvider.encrypt(secondKey, newPassword, wallet.address, wallet.iv);
           // wallet.secondBip38 = this.forgeProvider.encryptBip38(secondWif, newPassword, this.currentNetwork);
         }
@@ -201,9 +205,9 @@ export class UserDataProvider {
   }
 
   getWalletByAddress(address: string, profileId: string = this.authProvider.loggedProfileId): Wallet {
-    if (lodash.isUndefined(profileId)) return;
+    if (lodash.isUndefined(profileId)) { return; }
 
-    let profile = this.getProfileById(profileId);
+    const profile = this.getProfileById(profileId);
     let wallet = new Wallet();
 
     if (profile.wallets[address]) {
@@ -216,15 +220,15 @@ export class UserDataProvider {
   }
 
   saveWallet(wallet: Wallet, profileId: string = this.authProvider.loggedProfileId, notificate: boolean = false) {
-    if (lodash.isUndefined(profileId)) return;
+    if (lodash.isUndefined(profileId)) { return; }
 
-    let profile = this.getProfileById(profileId);
+    const profile = this.getProfileById(profileId);
     wallet.lastUpdate = new Date().getTime();
     profile.wallets[wallet.address] = wallet;
 
     this.profiles[profileId] = profile;
 
-    if (notificate) this.onUpdateWallet$.next(wallet);
+    if (notificate) { this.onUpdateWallet$.next(wallet); }
 
     return this.saveProfiles();
   }
@@ -266,9 +270,9 @@ export class UserDataProvider {
   }
 
   getKeysByWallet(wallet: Wallet, password: string): WalletKeys {
-    if (!wallet.cipherKey && !wallet.cipherSecondKey) return;
+    if (!wallet.cipherKey && !wallet.cipherSecondKey) { return; }
 
-    let keys: WalletKeys = {};
+    const keys: WalletKeys = {};
 
     if (wallet.cipherKey) {
       keys.key = this.forgeProvider.decrypt(wallet.cipherKey, password, wallet.address, wallet.iv);
@@ -282,9 +286,9 @@ export class UserDataProvider {
   }
 
   private setCurrentNetwork(): void {
-    if (!this.currentProfile) return;
+    if (!this.currentProfile) { return; }
 
-    let network = new Network();
+    const network = new Network();
 
     Object.assign(network, this.networks[this.currentProfile.networkId]);
     this.onActivateNetwork$.next(network);
@@ -294,9 +298,9 @@ export class UserDataProvider {
 
   private setCurrentProfile(profileId: string, broadcast: boolean = true): void {
     if (profileId && this.profiles[profileId]) {
-      let profile = new Profile().deserialize(this.profiles[profileId]);
+      const profile = new Profile().deserialize(this.profiles[profileId]);
       this.currentProfile = profile;
-      if (broadcast) this.onSelectProfile$.next(profile);
+      if (broadcast) { this.onSelectProfile$.next(profile); }
     } else {
       this.currentProfile = null;
       this.authProvider.logout(false);

--- a/src/utils/ark-utility.ts
+++ b/src/utils/ark-utility.ts
@@ -1,5 +1,5 @@
 import * as constants from '@app/app.constants';
-import BigNumber from "bignumber.js";
+import BigNumber from 'bignumber.js';
 
 export class ArkUtility {
   public static getRandomInt(min: number, max: number): number {

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,106 @@
     "no-duplicate-variable": true,
     "no-unused-variable": [
       true
+    ],
+    "arrow-return-shorthand": true,
+    "class-name": true,
+    "comment-format": [
+      true,
+      "check-space"
+    ],
+    "curly": true,
+    "deprecation": {
+      "severity": "warn"
+    },
+    "eofline": true,
+    "import-blacklist": [
+      true,
+      "rxjs",
+      "rxjs/Rx"
+    ],
+    "import-spacing": true,
+    "indent": [
+      true,
+      "spaces"
+    ],
+    "interface-over-type-literal": true,
+    "label-position": true,
+    "max-line-length": [
+      true,
+      140
+    ],
+    "member-access": false,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-console": [
+      true,
+      "debug",
+      "info",
+      "time",
+      "timeEnd",
+      "trace"
+    ],
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-super": true,
+    "no-empty": false,
+    "no-empty-interface": true,
+    "no-eval": true,
+    "no-inferrable-types": [
+      true,
+      "ignore-params"
+    ],
+    "no-misused-new": true,
+    "no-non-null-assertion": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": false,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": true,
+    "no-trailing-whitespace": true,
+    "no-unnecessary-initializer": true,
+    "no-unused-expression": true,
+    "no-use-before-declare": true,
+    "no-var-keyword": true,
+    "object-literal-sort-keys": false,
+    "one-line": [
+      true,
+      "check-open-brace",
+      "check-catch",
+      "check-else",
+      "check-whitespace"
+    ],
+    "prefer-const": true,
+    "quotemark": [
+      true,
+      "single"
+    ],
+    "semicolon": [
+      true,
+      "strict-bound-class-methods"
+    ],
+    "triple-equals": [
+      true,
+      "allow-null-check"
+    ],
+    "typedef-whitespace": [
+      true,
+      {
+        "call-signature": "nospace",
+        "index-signature": "nospace",
+        "parameter": "nospace",
+        "property-declaration": "nospace",
+        "variable-declaration": "nospace"
+      }
+    ],
+    "unified-signatures": true,
+    "variable-name": false,
+    "whitespace": [
+      true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-separator",
+      "check-type"
     ]
   },
   "rulesDirectory": [


### PR DESCRIPTION
Travis currently only does the following:

- `npm run lint --bailOnLintError true`
- `npm run build -- --prod`

I didn't add an android build or even attempt to, because for me at the moment it's more important to ensure the code style & ensure the compilation / build works in general

I also updated `tslint.config` to match the one from `ark-explorer`.
I think it makes sense to have the same tslint in both project, since both are with angular 2+.
However I removed the following rules:
 - `"forin": true` ([source](https://palantir.github.io/tslint/rules/forin/))
   - reason: I don't like the enforcement of having to do the `hasOwnProperty` all the time
- `"radix": true` ([source](https://palantir.github.io/tslint/rules/radix/))
  - reason: find it unnecessary, never heard of t not wanting/not having the default of 10
- `member-ordering` ([source](https://palantir.github.io/tslint/rules/member-ordering/))
  - reason: the ordering was ` "static-field",  "instance-field", "static-method",  "instance-method"` which I can't agree with, if you want I can insert another order?

Do you have any input on the rules?
Any more rules you'd like to see? For example we could enforce or disable `public` for methods and field or we could enforce to always have `types` on methods.

ToDo's from your site (before merge):

- [x] enable Travis for `ark-mobile` 