### PR TITLE
Improve german translations & add script to find missing translations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ install:
   - npm install
 
 script:
+  - npm run missing-translations
   - npm run lint  --bailOnLintError true
   - npm run build -- --prod

--- a/missing-translations.js
+++ b/missing-translations.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+
+const i18nDir = path.join(__dirname, '//src//assets//i18n');
+const masterFileName = 'en.json';
+
+const getMissingKeys = (master, slave, missingKeys, pathPrefix) => {
+  if (!missingKeys) {
+    missingKeys = [];
+  }
+
+  if (typeof master !== 'object') {
+    return missingKeys;
+  }
+
+  Object.keys(master).forEach(key => {
+    const slaveValue = slave ? slave[key] : slave
+    const pathKey = pathPrefix ? `${pathPrefix}.${key}` : key;
+    if (!slaveValue) {
+      missingKeys.push(pathKey);
+    }
+    getMissingKeys(master[key], slaveValue, missingKeys, pathKey);
+  });
+
+  return missingKeys;
+};
+
+fs.readFile(path.join(i18nDir, masterFileName), 'utf8', (err, masterJson) => {
+  fs.readdir(i18nDir, (err, files) => {
+    files.filter(fileName => fileName !== masterFileName).forEach((fileName) => {
+      fs.readFile(path.join(i18nDir, fileName), 'utf8', (err, json) => {
+        const missingKeys = getMissingKeys(JSON.parse(masterJson), JSON.parse(json));
+        if (missingKeys.length) {
+          console.log(`Missing translations in ${fileName} (${missingKeys.length}):`);
+          missingKeys.forEach(key => console.log(`  ${key}`));
+        } else {
+          console.log(`File ${fileName} has no missing translations`);
+        }
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
         "lint": "ionic-app-scripts lint",
         "ionic:build": "ionic-app-scripts build",
         "ionic:serve": "ionic-app-scripts serve",
-        "ionic:lab": "ionic-app-scripts serve --lab"
+        "ionic:lab": "ionic-app-scripts serve --lab",
+        "missing-translations": "node missing-translations"
     },
     "dependencies": {
         "@angular/common": "4.4.3",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1,6 +1,8 @@
 {
   "API": {
     "BALANCE_TOO_LOW": "Saldo zu gering für Transaktion",
+    "BALANCE_TOO_LOW_DETAIL": "Nicht genug {{ token }} auf deinem Wallet! Die Transaktionskosten sind: {{ totalAmount }} ({{ amount }} + {{ fee }} Gebühr), dein Wallet Saldo ist jedoch nur {{ balance }}!",
+    "DESTINATION_ADDRESS_ERROR": "Die Zieladresse '{{ address }} ist fehlerhaft",
     "PEER_LIST_ERROR": "Konnte Peers Liste nicht finden",
     "TRANSACTION_FAILED": "Transaktion fehlgeschlagen",
     "TRANSACTION_SENT": "Transaktion durchgeführt"
@@ -64,7 +66,7 @@
   "LOGIN_PAGE": {
     "ARK_WALLET": "ARK Wallet",
     "CREATE_PROFILE": "Erstelle ein Profil",
-    "SLOGAN": "Wilkommen zum ARK Ecosystem"
+    "SLOGAN": "Willkommen beim ARK Ecosystem"
   },
   "LOGOUT_PROFILE_TEXT": "Ausloggen?",
   "MARKETS_PAGE": {
@@ -87,8 +89,12 @@
     "INTERNET_DESCONNECTED": "Internet Verbindung nicht möglich!",
     "PEER": "Peer"
   },
-  "NEXT": "Nächste",
+  "NEXT": "Weiter",
   "NO": "Nein",
+  "PASSPHRASE_TEST": {
+    "INFO": "Um die Wallet Erstellung abzuschliessen, gib bitte die verlangten Wörter von deiner Passphrase ein.",
+    "WRONG_WORD": "Das eingegebene Wort ist nicht richtig"
+  },
   "PIN_CODE": {
     "CONFIRM": "Bestätige deinen PIN",
     "CREATE": "Erstelle deinen PIN",
@@ -161,14 +167,15 @@
     "MULTISIGNATURE_CREATION": "Multisignatur erzeugen",
     "OPEN_EXPLORER": "Öffnen in Explorer",
     "QRCODE_COPY": "Klicke auf die Adresse, um sie zu kopieren oder klicke auf das Icon um den QR Code zu teilen.",
-    "RECEIVE": "Erhalten",
-    "RECEIVED": "Erhalten",
-    "RECEIVED_FROM": "Erhalten von",
+    "RECEIVE": "Empfangen",
+    "RECEIVE_TOKEN": "{{ Token }} Empfangen",
+    "RECEIVED": "Empfangen",
+    "RECEIVED_FROM": "Empfangen von",
     "RECIPIENT": "Empfänger",
     "SECOND_SIGNATURE_CREATION": "Zweite Signatur erzeugen",
     "SECOND_PASSPHRASE_NOT_ENTERED": "Die zweite Signatur wurde nicht eingegeben",
     "SEND": "Senden",
-    "SEND_ALL": "Alle senden",
+    "SEND_ALL": "Alles senden",
     "SEND_TOKEN_TO_ADDRESS": "Sende {{ token }} an {{ address }}",
     "SENT": "Gesendet",
     "SENT_TO": "Gesendet an",
@@ -218,7 +225,7 @@
     "SECRET_PASSPHRASE": "Geheime Passphrase",
     "SECRET_PASSPHRASE_KEEP_SAFE": "Bewahre es sicher auf!",
     "SEED": "Seed",
-    "TOTAL_BALANCE": "Gesamtsumme",
+    "TOTAL_BALANCE": "Total",
     "USERNAME": "Benutzername",
     "WALLETS": "Wallets",
     "WIF": "WIF"
@@ -233,5 +240,6 @@
     "TUESDAY": "Di",
     "WEDNESDAY": "Mi"
   },
+  "WORD": "Wort",
   "YES": "Ja"
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -2,7 +2,7 @@
   "API": {
     "BALANCE_TOO_LOW": "Balance too low for transaction",
     "BALANCE_TOO_LOW_DETAIL": "Not enough {{ token }} on your account! The transaction costs are: {{ totalAmount }} ({{ amount }} + {{ fee }} fee). However your account balance is only {{ balance }}!",
-    "DESTINATION_ADDRESS_ERROR": "The destination address {{ address }} is erroneous",
+    "DESTINATION_ADDRESS_ERROR": "The destination address '{{ address }}' is erroneous",
     "PEER_LIST_ERROR": "Could not get list of peers",
     "TRANSACTION_FAILED": "Transaction failed",
     "TRANSACTION_SENT": "Transaction was sent"
@@ -168,6 +168,7 @@
     "OPEN_EXPLORER": "Open in Explorer",
     "QRCODE_COPY": "Tap on address to copy it to clipboard or click on icon to share QR code.",
     "RECEIVE": "Receive",
+    "RECEIVE_TOKEN": "Receive {{ Token }}",
     "RECEIVED": "Received",
     "RECEIVED_FROM": "Received from",
     "RECIPIENT": "Recipient",

--- a/src/pages/transaction/transaction-receive/transaction-receive.html
+++ b/src/pages/transaction/transaction-receive/transaction-receive.html
@@ -1,7 +1,7 @@
 <ion-header no-shadow no-border>
 
   <ion-navbar>
-    <ion-title>{{ 'TRANSACTIONS_PAGE.RECEIVE' | translate }} {{ token }}</ion-title>
+    <ion-title>{{ 'TRANSACTIONS_PAGE.RECEIVE_TOKEN' | translate:tokenParam }}</ion-title>
     <ion-buttons end>
       <button ion-button icon-only (click)="share()">
         <ion-icon name="share"></ion-icon>

--- a/src/pages/transaction/transaction-receive/transaction-receive.ts
+++ b/src/pages/transaction/transaction-receive/transaction-receive.ts
@@ -15,7 +15,7 @@ export class TransactionReceivePage {
 
   public address;
   public qraddress: any;
-  public token;
+  public tokenParam: Object;
 
   constructor(
     public navCtrl: NavController,
@@ -25,7 +25,7 @@ export class TransactionReceivePage {
     private socialSharing: SocialSharing,
   ) {
     this.address = this.navParams.get('address');
-    this.token = this.navParams.get('token');
+    this.tokenParam = {Token: this.navParams.get('token')};
 
     this.qraddress = `'{"a": "${this.address}"}'`;
   }


### PR DESCRIPTION
This fixes some translations in german.

Please note:
Whenever possible we should **inlcude** parameters in the translation text, and not just "append" them, because in other languages (i.e. in this case in german) the word is not in the same place

I also realized it's hard to find out which translations are actually missing.
I googled if `ngx` offers anythign concering that, unfortunately I couldn't find something.
So I wrote a small script, which displays all missing translations keys on the console.
I added this to travis. Maybe later we can publish the results to some file or something like that, so that it can be easily picked up.

The result looks like this:

```
Missing translations in gr.json (7):
  API.BALANCE_TOO_LOW_DETAIL
  API.DESTINATION_ADDRESS_ERROR
  PASSPHRASE_TEST
  PASSPHRASE_TEST.INFO
  PASSPHRASE_TEST.WRONG_WORD
  TRANSACTIONS_PAGE.RECEIVE_TOKEN
  WORD
Missing translations in it.json (7):
  API.BALANCE_TOO_LOW_DETAIL
  API.DESTINATION_ADDRESS_ERROR
  PASSPHRASE_TEST
  PASSPHRASE_TEST.INFO
  PASSPHRASE_TEST.WRONG_WORD
  TRANSACTIONS_PAGE.RECEIVE_TOKEN
  WORD
File de.json has no missing translations
Missing translations in nl.json (8):
  API.BALANCE_TOO_LOW_DETAIL
  API.DESTINATION_ADDRESS_ERROR
  NETWORKS_PAGE.PEER
  PASSPHRASE_TEST
  PASSPHRASE_TEST.INFO
  PASSPHRASE_TEST.WRONG_WORD
  TRANSACTIONS_PAGE.RECEIVE_TOKEN
  WORD
Missing translations in ru.json (7):
  API.BALANCE_TOO_LOW_DETAIL
  API.DESTINATION_ADDRESS_ERROR
  PASSPHRASE_TEST
  PASSPHRASE_TEST.INFO
  PASSPHRASE_TEST.WRONG_WORD
  TRANSACTIONS_PAGE.RECEIVE_TOKEN
  WORD
Missing translations in sv.json (7):
  API.BALANCE_TOO_LOW_DETAIL
  API.DESTINATION_ADDRESS_ERROR
  PASSPHRASE_TEST
  PASSPHRASE_TEST.INFO
  PASSPHRASE_TEST.WRONG_WORD
  TRANSACTIONS_PAGE.RECEIVE_TOKEN
  WORD
```

