### PR TITLE
2 bug fixes & translation update

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -99,6 +99,8 @@
     "CONFIRM": "Bestätige deinen PIN",
     "CREATE": "Erstelle deinen PIN",
     "DEFAULT_MESSAGE": "Gib deinen PIN ein",
+    "WRONG_PIN_MANY_TIMES": "Du hast zu viele Male einen falschen PIN eingegeben.",
+    "WAIT_TO_TRY": "Bitte warte {{ time }} und versuche es noch einmal",
     "LOGIN_ERROR": "Es gab ein Problem beim Einloggen mit deinem PIN",
     "PIN_CREATED_ERROR_TEXT": "Es gab ein Problem beim Erstellen deines PINs",
     "PIN_CREATED_TEXT": "Dein PIN wurde erstellt",

--- a/src/components/pin-code/pin-code.ts
+++ b/src/components/pin-code/pin-code.ts
@@ -17,6 +17,7 @@ export class PinCodeComponent {
 
   @Output('onSuccess') onSuccess: EventEmitter<WalletKeys> = new EventEmitter();
   @Output('onWrong') onWrong: EventEmitter<void> = new EventEmitter();
+  @Output('onClosed') onClosed: EventEmitter<void> = new EventEmitter();
 
   constructor(
     private userDataProvider: UserDataProvider,
@@ -38,7 +39,7 @@ export class PinCodeComponent {
     });
 
     modal.onDidDismiss((password) => {
-      if (lodash.isNil(password)) { return this.onWrong.emit(); }
+      if (lodash.isNil(password)) { return this.onClosed.emit(); }
 
       const loader = this.loadingCtrl.create({
         dismissOnPageChange: true,

--- a/src/modals/pin-code/pin-code.ts
+++ b/src/modals/pin-code/pin-code.ts
@@ -103,8 +103,8 @@ export class PinCodeModal implements OnDestroy {
   setWrong() {
     this.vibration.vibrate(constants.VIBRATION_TIME_LONG_MS);
 
-    this.authProvider.increaseAttempts().subscribe(() => {
-      this.attempts++;
+    this.authProvider.increaseAttempts().subscribe((newAttempts) => {
+      this.attempts = newAttempts;
       this.verifyAttempts();
 
       this.zone.run(() => {

--- a/src/providers/auth/auth.ts
+++ b/src/providers/auth/auth.ts
@@ -88,7 +88,10 @@ export class AuthProvider {
   }
 
   increaseAttempts() {
-    return this.getAttempts().do((attempts) => this.storage.set(constants.STORAGE_AUTH_ATTEMPTS, Number(attempts) + 1));
+    return this.getAttempts().mergeMap(attempts => {
+      const increasedAttempts = Number(attempts) + 1;
+      return this.storage.set(constants.STORAGE_AUTH_ATTEMPTS, increasedAttempts).map(() => increasedAttempts);
+    });
   }
 
   increaseUnlockTimestamp(): Promise<Date> {


### PR DESCRIPTION
- fix race condition in increasing attempts
  - problem was, that the "storage.set" method is async and therefore was not always done, when the next call to increasedAttempts was made, therefore sometimes an old value was returned.
  - This resulted in the problem, that you still had infinite tries to "brute-force" the pin
-  don't show error when pin code dialog is closed (when signing in)
- german translations updated :>

Hope my `mergeMap` usage is correct, always find this hard!

Probably a PR for @luciorubeens since you implemented that attempt-stuff.