### PR TITLE
Use user's locale as default app language

### DIFF
--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -1,3 +1,4 @@
+
 export class UserSettings {
   public language: string;
   public currency: string;
@@ -6,9 +7,9 @@ export class UserSettings {
 
   constructor() {}
 
-  public static defaults(): UserSettings {
+  public static defaults(lang: string): UserSettings {
     const settings = new UserSettings();
-    settings.language = 'en';
+    settings.language = lang;
     settings.currency = 'usd';
     settings.darkMode = false;
     settings.notification = false;

--- a/src/pages/intro/intro.ts
+++ b/src/pages/intro/intro.ts
@@ -17,7 +17,7 @@ export class IntroPage {
   public activeIndex = 0;
 
   constructor(
-    private platform: Platform,
+    public platform: Platform,
     private navCtrl: NavController,
     private authProvider: AuthProvider,
     private translateService: TranslateService,

--- a/src/pages/intro/intro.ts
+++ b/src/pages/intro/intro.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild } from '@angular/core';
-import { IonicPage, NavController, Slides } from 'ionic-angular';
+import { IonicPage, NavController, Platform, Slides } from 'ionic-angular';
 
 import { AuthProvider } from '@providers/auth/auth';
 import { TranslateService } from '@ngx-translate/core';
@@ -17,35 +17,38 @@ export class IntroPage {
   public activeIndex = 0;
 
   constructor(
+    private platform: Platform,
     private navCtrl: NavController,
     private authProvider: AuthProvider,
     private translateService: TranslateService,
   ) {
-    this.translateService.get([
-      'INTRO_PAGE.WELCOME',
-      'INTRO_PAGE.TEXT_1',
-      'INTRO_PAGE.SECURITY',
-      'INTRO_PAGE.TEXT_2',
-      'INTRO_PAGE.FAST_EASY',
-      'INTRO_PAGE.TEXT_3',
-    ]).subscribe((translation) => {
-      this.slides = [
-        {
-          title: translation['INTRO_PAGE.WELCOME'],
-          image: 'assets/img/light/intro/24_7.png',
-          description: translation['INTRO_PAGE.TEXT_1'],
-        },
-        {
-          title: translation['INTRO_PAGE.SECURITY'],
-          image: 'assets/img/light/intro/pincode.png',
-          description: translation['INTRO_PAGE.TEXT_2'],
-        },
-        {
-          title: translation['INTRO_PAGE.FAST_EASY'],
-          image: 'assets/img/light/intro/fast_easy.png',
-          description: translation['INTRO_PAGE.TEXT_3'],
-        },
-      ];
+    platform.ready().then(() => {
+      this.translateService.get([
+        'INTRO_PAGE.WELCOME',
+        'INTRO_PAGE.TEXT_1',
+        'INTRO_PAGE.SECURITY',
+        'INTRO_PAGE.TEXT_2',
+        'INTRO_PAGE.FAST_EASY',
+        'INTRO_PAGE.TEXT_3',
+      ]).subscribe((translation) => {
+        this.slides = [
+          {
+            title: translation['INTRO_PAGE.WELCOME'],
+            image: 'assets/img/light/intro/24_7.png',
+            description: translation['INTRO_PAGE.TEXT_1'],
+          },
+          {
+            title: translation['INTRO_PAGE.SECURITY'],
+            image: 'assets/img/light/intro/pincode.png',
+            description: translation['INTRO_PAGE.TEXT_2'],
+          },
+          {
+            title: translation['INTRO_PAGE.FAST_EASY'],
+            image: 'assets/img/light/intro/fast_easy.png',
+            description: translation['INTRO_PAGE.TEXT_3'],
+          },
+        ];
+      });
     });
   }
 

--- a/src/pages/intro/intro.ts
+++ b/src/pages/intro/intro.ts
@@ -17,7 +17,7 @@ export class IntroPage {
   public activeIndex = 0;
 
   constructor(
-    public platform: Platform,
+    platform: Platform,
     private navCtrl: NavController,
     private authProvider: AuthProvider,
     private translateService: TranslateService,

--- a/src/providers/settings-data/settings-data.ts
+++ b/src/providers/settings-data/settings-data.ts
@@ -64,7 +64,11 @@ export class SettingsDataProvider {
   }
 
   public getDefaults(): UserSettings {
-    return UserSettings.defaults(this.translateService.getBrowserLang());
+    let userLocale = this.translateService.getBrowserLang();
+    if (this.AVALIABLE_OPTIONS.languages[userLocale] === undefined) {
+      userLocale = 'en'; // Default to English if we don't support user's language yet
+    }
+    return UserSettings.defaults(userLocale);
   }
 
   public save(options?: UserSettings): Observable<any> {

--- a/src/providers/settings-data/settings-data.ts
+++ b/src/providers/settings-data/settings-data.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { StorageProvider } from '@providers/storage/storage';
+import { TranslateService } from '@ngx-translate/core';
 
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -47,7 +48,7 @@ export class SettingsDataProvider {
     },
   };
 
-  constructor(private _storageProvider: StorageProvider) {
+  constructor(private _storageProvider: StorageProvider, private translateService: TranslateService) {
     this.load().subscribe((data) => {
       this._settings = data;
       this.save();
@@ -63,7 +64,7 @@ export class SettingsDataProvider {
   }
 
   public getDefaults(): UserSettings {
-    return UserSettings.defaults();
+    return UserSettings.defaults(this.translateService.getBrowserLang());
   }
 
   public save(options?: UserSettings): Observable<any> {


### PR DESCRIPTION
When starting the app for the first time, you'll see a short introduction. This introduction was not properly translated when you set a different language, as the translationService still returned the English values. I've deferred the retrieval of the translations by waiting for the platform.ready() call, but I am not sure whether this is the right way to go. If there is a better way to wait for a translation to be set in Ionic, then let me know!

If you want to review this issue, you can do so as follows:

1) In `app/app.components.ts`, set a different language than 'en' (e.g. 'nl'):
`this.translateService.use('nl'); // Set your language here`

2) Reinstall the app so you'll see the introduction again. The introduction slides will be in English, while the buttons will be translated into the correct language

3) Apply the fix in this PR and now the slides should be translated as well!