### PR TITLE
Added phrase that was not yet translated

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -211,6 +211,7 @@
     "MY_WALLET": "My Wallet",
     "NEW_WALLET_NAME": "New wallet name",
     "NO_TRANSACTIONS": "No transactions available",
+    "OR_TYPE": "or type",
     "PASSPHRASE": "Passphrase",
     "PASSPHRASE_NOT_MATCH": "The passphrase entered does not match the one you just got.",
     "PUBLIC_ADDRESS": "Public Address",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -89,7 +89,7 @@
     "INTERNET_DESCONNECTED": "Verbinding maken met internet mislukt!",
     "PEER": "Peer"
   },
-  "NEXT": "Volgende",
+  "NEXT": "Verder",
   "NO": "Nee",
   "PASSPHRASE_TEST": {
     "INFO": "Type alsjeblieft de gevraagde woorden van je passphrase om de wallet aanmaak te valideren.",
@@ -211,6 +211,7 @@
     "MY_WALLET": "Mijn Wallet",
     "NEW_WALLET_NAME": "Nieuwe wallet naam",
     "NO_TRANSACTIONS": "Geen transacties beschikbaar",
+    "OR_TYPE": "of type",
     "PASSPHRASE": "Passphrase",
     "PASSPHRASE_NOT_MATCH": "De ingevulde passphrase komt niet overeen met degene die je zojuist had gekregen.",
     "PUBLIC_ADDRESS": "Openbaar Adres",

--- a/src/pages/wallet/wallet-import/wallet-import.html
+++ b/src/pages/wallet/wallet-import/wallet-import.html
@@ -24,7 +24,7 @@
           </ion-row>
           <ion-row>
             <ion-col>
-              <p>or type <a (click)="openWalletImportPassphrase()" tappable>{{ 'WALLETS_PAGE.SECRET_PASSPHRASE' | translate }}</a></p>
+              <p>{{ 'WALLETS_PAGE.OR_TYPE' | translate }} <a (click)="openWalletImportPassphrase()" tappable>{{ 'WALLETS_PAGE.SECRET_PASSPHRASE' | translate }}</a></p>
             </ion-col>
           </ion-row>
         </ion-grid>


### PR DESCRIPTION
In the 'Import wallet' screen, part of the 'or type secret passphrase' sentence was not being translated