### PR TITLE
Fix issue with user locale not using correct key

### DIFF
--- a/src/providers/settings-data/settings-data.ts
+++ b/src/providers/settings-data/settings-data.ts
@@ -66,7 +66,9 @@ export class SettingsDataProvider {
   public getDefaults(): UserSettings {
     const cultureLang = this.translateService.getBrowserCultureLang();
     const browserLang = this.translateService.getBrowserLang();
-    const appLang = this.AVALIABLE_OPTIONS.languages[cultureLang] || this.AVALIABLE_OPTIONS.languages[browserLang] || 'en';
+    const appLang = this.AVALIABLE_OPTIONS.languages[cultureLang] ? cultureLang
+      : this.AVALIABLE_OPTIONS.languages[browserLang] ? browserLang
+      : 'en';
 
     return UserSettings.defaults(appLang);
   }


### PR DESCRIPTION
Translations were broken after commit https://github.com/ArkEcosystem/ark-mobile/commit/42aaec81de22d6c959b68e291b8161ba42357a1e, due to the following:

`const appLang = this.AVALIABLE_OPTIONS.languages[cultureLang] || this.AVALIABLE_OPTIONS.languages[browserLang] || 'en';`

This works in case the option list does not contain `cultureLang` or `browserLang`, as it will default to 'en'. However, if it does contain `cultureLang` or `browserLang`, the selected value in `appLang` will be incorrect as the value of the option is taken (while the key corresponds to the actual language file). To give a more concrete example:

Let's say that we have our mobile device set to Dutch. Culturelang will return `nl-NL`, which is not available in the list of options, and browserlang will be `nl`. As a result, `this.AVALIABLE_OPTIONS.languages[browserLang]` will be stored in `appLang`, which is "Nederlands". The app will then try to look for `Nederlands.json`, while the file is called `nl.json` instead.

This PR makes sure that we use the key again, so we are able to find the correct translation file. 
