### PR TITLE
Enabled 2nd passphrase modal when sending transaction

### DIFF
--- a/src/modals/enter-second-passphrase/enter-second-passphrase.html
+++ b/src/modals/enter-second-passphrase/enter-second-passphrase.html
@@ -15,7 +15,7 @@
   <form #ngForm="ngForm">
     <ion-item>
       <ion-label stacked>{{ 'WALLETS_PAGE.ENTER_SECRET_PASSPHRASE' | translate }}</ion-label>
-      <ion-textarea rows="2" name="secondPassphrase" [(ngModel)]="passphrase"></ion-textarea>
+      <ion-textarea autocapitalize="off" rows="2" name="secondPassphrase" [(ngModel)]="passphrase"></ion-textarea>
     </ion-item>
   </form>
 </ion-content>

--- a/src/pages/transaction/transaction-send/transaction-send.ts
+++ b/src/pages/transaction/transaction-send/transaction-send.ts
@@ -102,7 +102,7 @@ export class TransactionSendPage implements OnInit {
       this.toastProvider.error('TRANSACTIONS_PAGE.INVALID_ADDRESS_ERROR');
     } else {
       this.createContact();
-      this.pinCode.open('PIN_CODE.TYPE_PIN_SIGN_TRANSACTION', true);
+      this.pinCode.open('PIN_CODE.TYPE_PIN_SIGN_TRANSACTION', true, true);
     }
   }
 

--- a/src/pages/transaction/transaction-send/transaction-send.ts
+++ b/src/pages/transaction/transaction-send/transaction-send.ts
@@ -200,7 +200,6 @@ export class TransactionSendPage implements OnInit {
       amount: amount.times(constants.WALLET_UNIT_TO_SATOSHI).toNumber(),
       vendorField: this.transaction.smartBridge,
       passphrase: keys.key,
-      secondPassphrase: keys.secondKey,
       recipientId: this.transaction.recipientAddress,
     };
 


### PR DESCRIPTION
If the wallet has a 2nd passphrase registered, it will now ask for this before sending the transaction instead of simply failing. Fixes #71 

This was actually easier to solve than I had expected 😛 