### PR TITLE
Fix runtime error on profile creation page

### DIFF
--- a/src/pages/profiles/profile-create/profile-create.html
+++ b/src/pages/profiles/profile-create/profile-create.html
@@ -6,7 +6,7 @@
 
 </ion-header>
 
-<ion-content padding class="full-height">
+<ion-content padding class="full-height" #content>
   <form #createProfileForm="ngForm" class="full-height">
     <ion-grid class="full-height">
       <ion-row class="create-field">
@@ -53,6 +53,6 @@
   </form>
 </ion-content>
 
-<ion-footer padding no-shadow no-border keyboard-attach>
+<ion-footer padding no-shadow no-border [keyboard-attach]="content">
   <button ion-button class="button-continue" [disabled]="!createProfileForm.form.valid" (click)="submitForm()">{{ 'NEXT' | translate }}</button>
 </ion-footer>


### PR DESCRIPTION
When creating a profile, the app would throw a runtime error when the keyboard came up to fill in a name. This is now fixed by adding a proper keyboard attach option.