### PR TITLE
Enable second passphrase creation

### DIFF
--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -152,6 +152,17 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
         });
       }
 
+      if (!this.wallet.isWatchOnly && !this.wallet.secondSignature) {
+        buttons.unshift({
+          text: translation['WALLETS_PAGE.SECOND_PASSPHRASE'],
+          role: 'label',
+          icon: !this.platform.is('ios') ? 'ios-lock-outline' : '',
+          handler: () => {
+            this.presentRegisterSecondPassphraseModal();
+          },
+        });
+      }
+
       const backupItem = {
         text: translation['SETTINGS_PAGE.WALLET_BACKUP'],
         role: 'label',
@@ -161,8 +172,6 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
         }
       };
 
-      // DEPRECATED:
-      // if (!this.wallet.isWatchOnly && !this.wallet.secondSignature) buttons.unshift(secondPassphraseItem);
       if (!this.wallet.isWatchOnly) { buttons.unshift(delegatesItem); } // "Watch Only" address can't vote
       if (!this.wallet.isWatchOnly && !this.wallet.isDelegate) { buttons.unshift(delegateItem); }
       if (!this.wallet.isWatchOnly) { buttons.splice(buttons.length - 1, 0, backupItem); }
@@ -341,6 +350,10 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
     .createSignature(keys.key, keys.secondPassphrase)
     .takeUntil(this.unsubscriber$)
     .subscribe((data) => {
+      // for the creation of the second signature we are not allowed to send the second key with it already
+      // if we do that we will get the exception 'Sender does not have a second signature'
+      keys.secondPassphrase = null;
+      keys.secondKey = null;
       this.confirmTransaction.open(data, keys);
     });
   }


### PR DESCRIPTION
It was very easy to integrate, I only had to fix a little thing.

However realized that a `deprecated` comment was above already existing code (which was commented).

So I asked @alexbarnsley if there was a reason for that / if second passphrase creation is on purpose not in the app anymore.
He told me I should just create this PR so that @luciorubeens can tell me why and if it was omitted by purpose, just close this  PR ;)