### PR TITLE
Update wallet delegate status on refresh

### DIFF
--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.html
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.html
@@ -4,7 +4,7 @@
     <button ion-button icon-only menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>
-    <ion-title>{{ wallet?.label ? wallet?.label : (wallet?.address | accountLabel: 'WALLETS_PAGE.MY_WALLET' | translate) }}</ion-title>
+    <ion-title>{{ wallet?.address | accountLabel: 'WALLETS_PAGE.MY_WALLET' | translate }}</ion-title>
     <ion-buttons end>
       <button ion-button icon-only (click)="presentWalletActionSheet()">
         <ion-icon name="md-more"></ion-icon>

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -329,7 +329,7 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
     switch (tx.type) {
       case TransactionType.CreateDelegate:
         const userName = tx.asset && tx.asset['delegate'] ? tx.asset['delegate'].username : null;
-        this.userDataProvider.setWalletDelegate(this.wallet, userName);
+        this.userDataProvider.ensureWalletDelegateProperties(this.wallet, userName);
         break;
     }
   };
@@ -381,17 +381,19 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
     this.marketDataProvider.refreshPrice();
   }
 
-  private refreshAccount(save: boolean = true) {
-    this.arkApiProvider.api.account.get({ address: this.address }).takeUntil(this.unsubscriber$).subscribe((response) => {
+  private refreshAccount() {
+    this.arkApiProvider.api.account.get({address: this.address}).takeUntil(this.unsubscriber$).subscribe((response) => {
       if (response.success) {
         this.wallet.deserialize(response.account);
-        if (save) { this.saveWallet(); }
+        this.arkApiProvider
+            .getDelegateByPublicKey(this.wallet.publicKey)
+            .subscribe(delegate => this.userDataProvider.ensureWalletDelegateProperties(this.wallet, delegate));
       }
     });
   }
 
   private refreshAllData() {
-    this.refreshAccount(false);
+    this.refreshAccount();
     this.refreshTransactions(false);
     this.saveWallet();
   }

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -385,6 +385,10 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
     this.arkApiProvider.api.account.get({address: this.address}).takeUntil(this.unsubscriber$).subscribe((response) => {
       if (response.success) {
         this.wallet.deserialize(response.account);
+        if (this.wallet.isDelegate) {
+          return;
+        }
+
         this.arkApiProvider
             .getDelegateByPublicKey(this.wallet.publicKey)
             .subscribe(delegate => this.userDataProvider.ensureWalletDelegateProperties(this.wallet, delegate));

--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -32,7 +32,7 @@
             <ion-item class="wallet">
               <ion-label [ngClass]="{delegate: wallet?.isDelegate, normal: !wallet?.isDelegate}">
                 <h2 class="amount">{{ currentNetwork?.symbol }} {{ wallet?.balance | unitsSatoshi }}</h2>
-                <p class="address">{{ wallet?.label || wallet?.address | accountLabel | truncateMiddle: 15 }}</p>
+                <p class="address">{{ wallet?.address | accountLabel | truncateMiddle: 15 }}</p>
                 <ion-badge class="watch-only-badge" [color]="wallet?.isDelegate ? 'primary' : 'danger-alternative'" *ngIf="wallet.isWatchOnly">{{ 'WATCH_ONLY' | translate }}</ion-badge>
               </ion-label>
             </ion-item>

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -14,6 +14,7 @@ import { v4 as uuid } from 'uuid';
 import { Network, NetworkType } from 'ark-ts/model';
 
 import * as constants from '@app/app.constants';
+import { Delegate } from 'ark-ts';
 
 @Injectable()
 export class UserDataProvider {
@@ -159,13 +160,28 @@ export class UserDataProvider {
     this.saveProfiles();
   }
 
-  setWalletDelegate(wallet: Wallet, username: string): void {
-    if (!wallet || !username) {
+  ensureWalletDelegateProperties(wallet: Wallet, delegateOrUserName: string | Delegate): void {
+    if (!wallet) {
+      return;
+    }
+
+    const userName: string = !delegateOrUserName || typeof delegateOrUserName === 'string'
+                               ? delegateOrUserName as string
+                               : delegateOrUserName.username;
+
+    if (!userName && (wallet.isDelegate || wallet.username)) {
+      wallet.isDelegate = false;
+      wallet.username = null;
+      this.saveWallet(wallet, undefined, true);
+      return;
+    }
+
+    if (!userName || (wallet.isDelegate && wallet.username === userName)) {
       return;
     }
 
     wallet.isDelegate = true;
-    wallet.username = username;
+    wallet.username = userName;
     this.saveWallet(wallet, undefined, true);
   }
 

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -169,13 +169,6 @@ export class UserDataProvider {
                                ? delegateOrUserName as string
                                : delegateOrUserName.username;
 
-    if (!userName && (wallet.isDelegate || wallet.username)) {
-      wallet.isDelegate = false;
-      wallet.username = null;
-      this.saveWallet(wallet, undefined, true);
-      return;
-    }
-
     if (!userName || (wallet.isDelegate && wallet.username === userName)) {
       return;
     }


### PR DESCRIPTION
- use accountLabel pipe consistently (don't user label if wallet is a delegate)

Note:
I wrote the `ensureWalletDelegateProperties` so that the wallet is only saved when the delegate state actually changed, i.e. you became a delegate.
Also what's different now is, that the wallet can actually be saved after a "walletRefresh" (method is called) happens, before we never saved it - hope that's not a problem.