### PR TITLE
Highlight the label of the accounts

### DIFF
--- a/src/modals/confirm-transaction/confirm-transaction.html
+++ b/src/modals/confirm-transaction/confirm-transaction.html
@@ -13,11 +13,13 @@
           <ion-item no-lines text-wrap>
             <ion-label stacked>
               <p>{{ 'TRANSACTIONS_PAGE.FROM' | translate }}</p>
-              <h6 ion-content>
+              <h6 ion-content class="account">
                 <span *ngIf="address | hasAccountLabel" class="account-label">
                   {{ address | accountLabel }}
                 </span>
-                {{address}}
+                <span>
+                  {{address}}
+                </span>
               </h6>
             </ion-label>
           </ion-item>
@@ -25,11 +27,13 @@
           <ion-item no-lines text-wrap *ngIf="transaction?.type == 0">
             <ion-label stacked>
               <p>{{ 'TRANSACTIONS_PAGE.RECIPIENT' | translate }}</p>
-              <h6 ion-content>
+              <h6 ion-content class="account">
                 <span *ngIf="transaction?.recipientId | hasAccountLabel" class="account-label">
                   {{ transaction?.recipientId | accountLabel }}
                 </span>
-                {{transaction?.recipientId}}
+                <span>
+                  {{transaction?.recipientId}}
+                </span>
               </h6>
             </ion-label>
           </ion-item>

--- a/src/modals/confirm-transaction/confirm-transaction.html
+++ b/src/modals/confirm-transaction/confirm-transaction.html
@@ -14,7 +14,7 @@
             <ion-label stacked>
               <p>{{ 'TRANSACTIONS_PAGE.FROM' | translate }}</p>
               <h6 ion-content>
-                <span *ngIf="address | hasAccountLabel">
+                <span *ngIf="address | hasAccountLabel" class="account-label">
                   {{ address | accountLabel }}
                 </span>
                 {{address}}
@@ -26,7 +26,7 @@
             <ion-label stacked>
               <p>{{ 'TRANSACTIONS_PAGE.RECIPIENT' | translate }}</p>
               <h6 ion-content>
-                <span *ngIf="transaction?.recipientId | hasAccountLabel">
+                <span *ngIf="transaction?.recipientId | hasAccountLabel" class="account-label">
                   {{ transaction?.recipientId | accountLabel }}
                 </span>
                 {{transaction?.recipientId}}

--- a/src/modals/confirm-transaction/confirm-transaction.scss
+++ b/src/modals/confirm-transaction/confirm-transaction.scss
@@ -29,8 +29,10 @@ modal-confirm-transaction {
   }
 
   h6 {
-    span {
-      display: block;
-    }
+		.account-label {
+			display: block;
+			font-weight: bold;
+		}
   }
+
 }

--- a/src/modals/confirm-transaction/confirm-transaction.scss
+++ b/src/modals/confirm-transaction/confirm-transaction.scss
@@ -28,11 +28,14 @@ modal-confirm-transaction {
     }
   }
 
-  h6 {
+  h6.account {
 		.account-label {
+			font-weight: 500;
 			display: block;
-			font-weight: bold;
-		}
+    }
+    span:not(.account-label) {
+      font-size: .9em;
+    }
   }
 
 }

--- a/src/pages/transaction/transaction-show/transaction-show.html
+++ b/src/pages/transaction/transaction-show/transaction-show.html
@@ -30,7 +30,7 @@
             <ion-label stacked>
               <p ion-text>{{ 'TRANSACTIONS_PAGE.TO' | translate }}</p>
               <h4 item-content class="content">
-                <span *ngIf="transaction?.recipientId | hasAccountLabel" class="block-span">
+                <span *ngIf="transaction?.recipientId | hasAccountLabel" class="account-label">
                   {{ transaction?.recipientId | accountLabel }}
                 </span>
                 {{ transaction?.recipientId }}
@@ -41,7 +41,7 @@
             <ion-label stacked>
               <p ion-text>{{ 'TRANSACTIONS_PAGE.FROM' | translate }}</p>
               <h4 item-content class="content">
-                <span *ngIf="transaction?.senderId | hasAccountLabel" class="block-span">
+                <span *ngIf="transaction?.senderId | hasAccountLabel" class="account-label">
                   {{ transaction?.senderId | accountLabel }}
                 </span>
                 {{ transaction?.senderId }}

--- a/src/pages/transaction/transaction-show/transaction-show.scss
+++ b/src/pages/transaction/transaction-show/transaction-show.scss
@@ -14,8 +14,9 @@ page-transaction-show {
     ion-row {
       padding: 1em 0;
     }
-    .block-span {
+    .account-label {
       display: block;
+      font-weight: bold;
     }
   }
 }

--- a/src/pages/transaction/transaction-show/transaction-show.scss
+++ b/src/pages/transaction/transaction-show/transaction-show.scss
@@ -14,9 +14,11 @@ page-transaction-show {
     ion-row {
       padding: 1em 0;
     }
-    .account-label {
-      display: block;
-      font-weight: bold;
+    h4 {
+      span.account-label {
+        display: block;
+        font-weight: 500;
+      }
     }
   }
 }


### PR DESCRIPTION
This is related to https://github.com/ArkEcosystem/ark-mobile/pull/76.

On the send confirmation modal and the transaction details page:

Previous | Now, transaction details | Now, send confirmation
------------ | -----------------------------------| --------------------------------
![Previously](https://user-images.githubusercontent.com/1161224/36395512-ce90d3f0-15b9-11e8-8e04-1eb3cde74aaa.png) | ![Now, transaction details](https://user-images.githubusercontent.com/1161224/36395509-ce6b9aa4-15b9-11e8-9697-59a92facbe8f.png) | ![Now, send confirmation](https://user-images.githubusercontent.com/1161224/36395508-ce2ebdc8-15b9-11e8-8b65-3ccf2ae79c18.png)

@luciorubeens any other similar change or a different style?