### PR TITLE
Fixed rounding to always adhere to specified decimals

### DIFF
--- a/src/pipes/market-number/market-number.ts
+++ b/src/pipes/market-number/market-number.ts
@@ -50,7 +50,7 @@ export class MarketNumberPipe implements PipeTransform, OnDestroy {
       decimalPlaces = 8;
     }
 
-    return Number(trueValue.toFixed(decimalPlaces));
+    return trueValue.toNumber().toFixed(decimalPlaces);
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
When showing fiat / BTC values in the app, there was a default of 2 and 8 decimals respectively. However, since the value was first changed to the required amount of decimals, and then turned into a Number, the decimals were lost if they ended in a 0. This means that the BTC values were actually shown in 7 decimals instead of 8, and fiat values were sometimes missing decimals (e.g. 4 or 4.1 instead of 4.00 and 4.10)

To fix this, I've changed the MarketNumber pipe to return the value of the toFixed() function instead of changing it to a number (so it now returns a string). As far as I could see, this should not have any adverse effects, as the pipe is only used when displaying information, which doesn't mind the value being a string instead of a number.