### PR TITLE
Show in explorer now makes use of external browser on transaction screen

### DIFF
--- a/src/pages/transaction/transaction-response/transaction-response.ts
+++ b/src/pages/transaction/transaction-response/transaction-response.ts
@@ -59,7 +59,7 @@ export class TransactionResponsePage {
 
   openInExplorer() {
     const url = `${this.currentNetwork.explorer}/tx/${this.transaction.id}`;
-    return this.iab.create(url);
+    return this.iab.create(url, '_system');
   }
 
   presentEncryptedAlert() {


### PR DESCRIPTION
Small change, but the "open in explorer" link on the transaction page still used the in-app browser. 