### PR TITLE
Removes grey square that appears in the corner of some pages

### DIFF
--- a/src/pages/contacts/contact-list/contact-list.scss
+++ b/src/pages/contacts/contact-list/contact-list.scss
@@ -1,3 +1,10 @@
 page-contact-list {
 
+  .content .scroll-content {
+    overflow-y: auto;
+  }
+  
+  .content-ios .scroll-content {
+    overflow-y: scroll;
+  }
 }

--- a/src/pages/network-status/network-status.scss
+++ b/src/pages/network-status/network-status.scss
@@ -1,8 +1,17 @@
 page-network-status {
-  scroll-content {
+  .scroll-content {
     display: flex;
     flex-direction: column;
   }
+
+  .content .scroll-content {
+    overflow-y: auto;
+  }
+  
+  .content-ios .scroll-content {
+    overflow-y: scroll;
+  }
+
   ion-grid {
     padding: 0;
     height: 100%;

--- a/src/pages/settings/settings.scss
+++ b/src/pages/settings/settings.scss
@@ -16,4 +16,12 @@ page-settings {
       }
     }
   }
+
+  .content .scroll-content {
+    overflow-y: auto;
+  }
+  
+  .content-ios .scroll-content {
+    overflow-y: scroll;
+  }
 }


### PR DESCRIPTION
Fixes #92 

The small grey square is due to the scrollviews in Ionic. As far as I was aware, this occurred on the Contacts, Settings and Network Status pages, so I fixed it there by adding `overflow-y: auto;`. Since it seems to be creating "momentum"  on iOS devices, we should have it set to `overflow-y: scroll` in that case. This can be achieved by using `.content-ios` according to [this comment](https://github.com/ionic-team/ionic/issues/6416#issuecomment-338752935), but I don't have an iOS device to properly test this.