### PR TITLE
Fix issue with unvoting delegate

### DIFF
--- a/src/pages/delegates/delegates.ts
+++ b/src/pages/delegates/delegates.ts
@@ -60,16 +60,16 @@ export class DelegatesPage implements OnDestroy {
   ) { }
 
   openDetailModal(delegate: Delegate) {
-    this.selectedDelegate = delegate;
 
     const modal = this.modalCtrl.create('DelegateDetailPage', {
       delegate,
       vote: this.walletVote,
     }, { cssClass: 'inset-modal-large', showBackdrop: false, enableBackdropDismiss: true });
 
-    modal.onDidDismiss((voter) => {
-      if (!voter) { return; }
+    modal.onDidDismiss((delegateVote) => {
+      if (!delegateVote) { return; }
 
+      this.selectedDelegate = delegateVote; // Save the delegate that we want to vote for
       this.pinCode.open('PIN_CODE.TYPE_PIN_SIGN_TRANSACTION', true, true);
 
     });
@@ -107,7 +107,7 @@ export class DelegatesPage implements OnDestroy {
   generateTransaction(keys: WalletKeys) {
     let type = VoteType.Add;
 
-    if (this.walletVote && this.walletVote.publicKey === this.selectedDelegate.publicKey) { type = VoteType.Remove; }
+    if (this.walletVote && this.walletVote.publicKey === this.selectedDelegate.publicKey ) { type = VoteType.Remove; }
 
     const data: TransactionVote = {
       delegatePublicKey: this.selectedDelegate.publicKey,


### PR DESCRIPTION
Fixes an issue where you were unable to unvote for a delegate.

Steps to reproduce the issue:

* When you have already voted for a delegate and want to vote for another, you can click on the new delegate and press 'Vote'.
* A modal will pop up stating that you have already voted for a delegate, and if you want to unvote the delegate.
* You can then press 'Unvote', fill in your PIN and a transaction will come up.
* When you send this transaction, you will receive the error that you can only vote for 1 delegate 

This PR solves the issue by making use of the data returned by the modal created in `delegate-details.ts`. That modal returns the actual delegate that we want to vote / unvote in its `dismiss()` function. By using that value in the `delegates.ts` file, we can correctly set the VoteType. Previously this value was ignored, meaning that if you clicked on a different delegate, that would erroneously be seen as the "selected delegate", which would result in a transaction to vote for this delegate, instead of unvoting the current one.

Tested all kinds of use cases on devnet and it seems to work as expected. Nevertheless, I encourage somebody else to also take a look into this before merging!