### PR TITLE
Added check for weak pin when creating one

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -114,7 +114,9 @@
     "PIN_UPDATED_TEXT": "Your PIN has been updated",
     "TYPE_PIN_ENCRYPT_PASSPHRASE": "Type your PIN to encrypt passphrase",
     "TYPE_PIN_SIGN_TRANSACTION": "Type your PIN to sign transaction",
-    "WRONG": "Please enter the correct PIN"
+    "WRONG": "Please enter the correct PIN",
+    "WEAK_PIN": "Weak PIN",
+    "WEAK_PIN_DETAIL": "The PIN you entered is considered weak and easy to guess. Are you sure you want to use it?"
   },
   "PROFILES_PAGE": {
     "ADD_PROFILE_ERROR": "Could not add profile",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -108,7 +108,9 @@
     "PIN_UPDATED_TEXT": "Je pincode is geüpdatet",
     "TYPE_PIN_ENCRYPT_PASSPHRASE": "Type pincode om passphrase te versleutelen",
     "TYPE_PIN_SIGN_TRANSACTION": "Type pincode om transactie te ondertekenen",
-    "WRONG": "Vul a.u.b. de juiste pincode in"
+    "WRONG": "Vul a.u.b. de juiste pincode in",
+    "WEAK_PIN": "Zwakke pincode",
+    "WEAK_PIN_DETAIL": "De opgegeven pincode is zwak en makkelijk te raden. Weet je zeker dat je deze wilt gebruiken?"
   },
   "PROFILES_PAGE": {
     "ADD_PROFILE_ERROR": "Kon profiel niet toevoegen",

--- a/src/providers/auth/auth.ts
+++ b/src/providers/auth/auth.ts
@@ -79,6 +79,17 @@ export class AuthProvider {
     });
   }
 
+  isWeakPassword(password: string): boolean {
+    const weakPasswords = [
+      '000000', '111111', '222222', '333333', '444444',
+      '555555', '666666', '777777', '888888', '999999',
+      '012345', '123456', '234567', '345678', '456789',
+      '567890', '543210', '654321', '765432', '876543',
+      '987654', '098765'
+    ];
+    return weakPasswords.indexOf(password) > -1;
+  }
+
   getUnlockTimestamp() {
     return this.storage.getObject(constants.STORAGE_AUTH_UNLOCK_TIMESTAMP);
   }


### PR DESCRIPTION
This PR adds a check for weak PINs when the user wants to create / update one. After a user fills in the 6 digit PIN, it is checked against a list of known weak pins. This is done with an array of values, as a regex is not a good fit for the consecutive digits in increasing / decreasing order, so it is much simpler and easier to understand by defining the weak pins this way. After a weak PIN has been found, the user will be presented with an alert as shown below:

![weak_pin_alert](https://user-images.githubusercontent.com/35610748/36940442-34df8902-1f43-11e8-852c-b466b72bee88.jpg)

Then the user can decide whether they want to keep the current PIN. When they press 'No', the PIN will be cleared and they can try another. By choosing 'Yes', the user will simply be send to the confirmation screen. This way you don't pressure a user into changing the PIN, but you can give them a little hint that they should choose another one if they want their funds to be safe.