### PR TITLE
Show 24h change for btc and fiat

### DIFF
--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -49,16 +49,21 @@
         <ion-grid class="no-padding" class="price-container">
           <ion-row nowrap justify-content-center align-items-baseline>
             <ion-col text-left *ngIf="fiatCurrency?.code !== 'btc'">
-              <p>{{ fiatCurrency?.code | uppercase }} <span class="fiat-bullet"></span></p>
-              <h6>{{ fiatCurrency?.symbol }}{{ fiatCurrency?.price | marketNumber }}</h6>
+              <p>{{ fiatCurrency?.code | uppercase }} / 24h <span class="fiat-bullet"></span></p>
+              <h6>
+                {{ fiatCurrency?.symbol }}{{ fiatCurrency?.price | marketNumber }}
+                /
+                <span ion-text [color]="fiatCurrency?.change24h < 0 ? 'danger' : 'secondary'">{{ fiatCurrency?.change24h | number: '1.2-2' }}%</span>
+              </h6>
             </ion-col>
             <ion-col text-left>
-              <p>{{ btcCurrency?.code | uppercase }} <span class="btc-bullet"></span></p>
-              <h6>{{ btcCurrency?.price | marketNumber: btcCurrency }}</h6>
-            </ion-col>
-            <ion-col text-left>
-              <p>{{ 'MARKETS_PAGE.PERCENTAGE_CHANGE' | translate }}</p>
-              <h6 ion-text [color]="fiatCurrency?.change24h < 0 ? 'danger' : 'secondary'">{{ fiatCurrency?.change24h | number: '1.2-2' }}%</h6>
+              <p>{{ btcCurrency?.code | uppercase }} / 24h <span class="btc-bullet"></span></p>
+              <h6>
+                {{ btcCurrency?.symbol }}{{ btcCurrency?.price | marketNumber: btcCurrency }}
+                /
+                <span ion-text [color]="btcCurrency?.change24h < 0 ? 'danger' : 'secondary'">{{ btcCurrency?.change24h | number: '1.2-2' }}%</span>
+              </h6>
+
             </ion-col>
           </ion-row>
         </ion-grid>


### PR DESCRIPTION
My first attempt is to simply show the 24h change for both currencies right next to the price - what do you guys think? I also think the `24h` label is enough to understand what the meaning behind the numbers are

![screenshot_20180311-153638](https://user-images.githubusercontent.com/1086065/37254735-47067690-2542-11e8-9cd3-439529c958fe.jpg)


edit: hmm the change fro BTC to almost all fiat currencies appears to be almost identical. Thought there might be an error in the code but it's probably correct.

@Levalicious what do you think?

Resolves #82