### PR TITLE
Remove useless angular-cli package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,97 +4,6 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
-        "@angular-cli/ast-tools": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/@angular-cli/ast-tools/-/ast-tools-1.0.16.tgz",
-            "integrity": "sha1-YxmULBol+4TjKUID6fejJmMvzlA=",
-            "dev": true,
-            "requires": {
-                "@angular/tsc-wrapped": "0.5.2",
-                "denodeify": "1.2.1",
-                "rxjs": "5.1.0",
-                "typescript": "2.0.10"
-            },
-            "dependencies": {
-                "denodeify": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-                    "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
-                    "dev": true
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                },
-                "mkdirp": {
-                    "version": "0.5.1",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                    "requires": {
-                        "minimist": "0.0.8"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "0.0.8",
-                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                        }
-                    }
-                },
-                "rxjs": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.1.0.tgz",
-                    "integrity": "sha1-CqkBi39EC1BfpCvXQrZzi+VQ5yA=",
-                    "dev": true,
-                    "requires": {
-                        "symbol-observable": "1.0.4"
-                    }
-                },
-                "source-map": {
-                    "version": "0.5.6",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                    "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-                },
-                "source-map-support": {
-                    "version": "0.4.11",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.11.tgz",
-                    "integrity": "sha1-ZH+TmXizhTWQlTCIUwPa8jJ58yI=",
-                    "requires": {
-                        "source-map": "0.5.6"
-                    }
-                },
-                "symbol-observable": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-                    "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
-                    "dev": true
-                },
-                "tsickle": {
-                    "version": "0.2.5",
-                    "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.2.5.tgz",
-                    "integrity": "sha1-YNjhJGLm+PvayS1fX+rSv0kIXYI=",
-                    "requires": {
-                        "minimist": "1.2.0",
-                        "mkdirp": "0.5.1",
-                        "source-map": "0.5.6",
-                        "source-map-support": "0.4.11"
-                    }
-                },
-                "typescript": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
-                    "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90=",
-                    "dev": true
-                }
-            }
-        },
-        "@angular-cli/base-href-webpack": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/@angular-cli/base-href-webpack/-/base-href-webpack-1.0.16.tgz",
-            "integrity": "sha1-Qpai/324TdwuZ8KhB+J29yRj/40=",
-            "dev": true
-        },
         "@angular-devkit/build-optimizer": {
             "version": "0.0.35",
             "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.35.tgz",
@@ -768,29 +677,6 @@
             "dev": true,
             "requires": {
                 "tslib": "1.8.0"
-            }
-        },
-        "@angular/tsc-wrapped": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-0.5.2.tgz",
-            "integrity": "sha1-Lt30csRn/LM06pTe3aqnGZDFpII=",
-            "dev": true,
-            "requires": {
-                "tsickle": "0.2.6"
-            },
-            "dependencies": {
-                "tsickle": {
-                    "version": "0.2.6",
-                    "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.2.6.tgz",
-                    "integrity": "sha1-rUq/kudOvfP7WqGHyoWwIGb+Ghs=",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "1.2.0",
-                        "mkdirp": "0.5.1",
-                        "source-map": "0.5.7",
-                        "source-map-support": "0.4.18"
-                    }
-                }
             }
         },
         "@ionic-native/clipboard": {
@@ -1801,778 +1687,12 @@
                 "semver": "5.4.1"
             }
         },
-        "angular-cli": {
-            "version": "1.0.0-beta.28.3",
-            "resolved": "https://registry.npmjs.org/angular-cli/-/angular-cli-1.0.0-beta.28.3.tgz",
-            "integrity": "sha1-l1HXQU6vjgtxSyRhpYW/2pcTQW8=",
-            "dev": true,
-            "requires": {
-                "@angular-cli/ast-tools": "1.0.16",
-                "@angular-cli/base-href-webpack": "1.0.16",
-                "@angular/compiler": "2.4.10",
-                "@angular/compiler-cli": "2.4.10",
-                "@angular/core": "2.4.10",
-                "@ngtools/json-schema": "1.1.0",
-                "@ngtools/webpack": "1.9.7",
-                "async": "2.6.0",
-                "autoprefixer": "6.7.7",
-                "chalk": "1.1.3",
-                "common-tags": "1.7.2",
-                "css-loader": "0.26.4",
-                "cssnano": "3.10.0",
-                "debug": "2.6.9",
-                "denodeify": "1.2.1",
-                "diff": "2.2.3",
-                "ember-cli-normalize-entity-name": "1.0.0",
-                "ember-cli-string-utils": "1.1.0",
-                "exists-sync": "0.0.3",
-                "extract-text-webpack-plugin": "2.1.2",
-                "file-loader": "0.8.5",
-                "findup": "0.1.5",
-                "fs-extra": "0.30.0",
-                "get-caller-file": "1.0.2",
-                "glob": "7.0.5",
-                "html-webpack-plugin": "2.30.1",
-                "inflection": "1.10.0",
-                "inquirer": "0.12.0",
-                "isbinaryfile": "2.0.4",
-                "json-loader": "0.5.7",
-                "karma-sourcemap-loader": "0.3.7",
-                "karma-webpack": "1.8.1",
-                "less": "2.7.3",
-                "less-loader": "2.2.3",
-                "lodash": "4.17.4",
-                "minimatch": "3.0.4",
-                "node-modules-path": "1.0.1",
-                "node-sass": "4.5.3",
-                "nopt": "3.0.6",
-                "opn": "4.0.1",
-                "ora": "0.2.3",
-                "portfinder": "1.0.9",
-                "postcss-loader": "0.9.1",
-                "raw-loader": "0.5.1",
-                "remap-istanbul": "0.6.4",
-                "resolve": "1.5.0",
-                "rimraf": "2.6.2",
-                "rsvp": "3.6.2",
-                "sass-loader": "4.1.1",
-                "script-loader": "0.7.2",
-                "semver": "5.4.1",
-                "silent-error": "1.1.0",
-                "source-map-loader": "0.1.6",
-                "sourcemap-istanbul-instrumenter-loader": "0.2.0",
-                "style-loader": "0.13.2",
-                "stylus": "0.54.5",
-                "stylus-loader": "2.5.1",
-                "temp": "0.8.3",
-                "through": "2.3.8",
-                "typescript": "2.0.10",
-                "url-loader": "0.5.9",
-                "walk-sync": "0.2.7",
-                "webpack": "2.2.0",
-                "webpack-dev-server": "2.2.0-rc.0",
-                "webpack-merge": "2.6.1",
-                "webpack-sources": "0.1.5",
-                "zone.js": "0.7.8"
-            },
-            "dependencies": {
-                "@angular/compiler": {
-                    "version": "2.4.10",
-                    "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-2.4.10.tgz",
-                    "integrity": "sha1-9R/TSCCyoCx8th+89JhzxYBW+ww=",
-                    "dev": true
-                },
-                "@angular/compiler-cli": {
-                    "version": "2.4.10",
-                    "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-2.4.10.tgz",
-                    "integrity": "sha1-whFDv6q0UjHI0uqoJFa+09OfkaM=",
-                    "dev": true,
-                    "requires": {
-                        "@angular/tsc-wrapped": "0.5.2",
-                        "minimist": "1.2.0",
-                        "reflect-metadata": "0.1.10"
-                    }
-                },
-                "@angular/core": {
-                    "version": "2.4.10",
-                    "resolved": "https://registry.npmjs.org/@angular/core/-/core-2.4.10.tgz",
-                    "integrity": "sha1-C4MgplBlll2ZhkWx9c0892m0Qeo=",
-                    "dev": true
-                },
-                "acorn": {
-                    "version": "4.0.13",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-                    "dev": true
-                },
-                "ajv": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                    "dev": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
-                },
-                "ajv-keywords": {
-                    "version": "1.5.1",
-                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-                    "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-                    "dev": true
-                },
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "autoprefixer": {
-                    "version": "6.7.7",
-                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-                    "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-                    "dev": true,
-                    "requires": {
-                        "browserslist": "1.7.7",
-                        "caniuse-db": "1.0.30000803",
-                        "normalize-range": "0.1.2",
-                        "num2fraction": "1.2.2",
-                        "postcss": "5.2.18",
-                        "postcss-value-parser": "3.3.0"
-                    }
-                },
-                "browserslist": {
-                    "version": "1.7.7",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-                    "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-                    "dev": true,
-                    "requires": {
-                        "caniuse-db": "1.0.30000803",
-                        "electron-to-chromium": "1.3.27"
-                    }
-                },
-                "camelcase": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                            "dev": true
-                        }
-                    }
-                },
-                "cliui": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                    "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                    "dev": true,
-                    "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
-                        "wordwrap": "0.0.2"
-                    }
-                },
-                "css-loader": {
-                    "version": "0.26.4",
-                    "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.26.4.tgz",
-                    "integrity": "sha1-th6eMNuUMD5v/IkvEOzQmtAlof0=",
-                    "dev": true,
-                    "requires": {
-                        "babel-code-frame": "6.26.0",
-                        "css-selector-tokenizer": "0.7.0",
-                        "cssnano": "3.10.0",
-                        "loader-utils": "1.1.0",
-                        "lodash.camelcase": "4.3.0",
-                        "object-assign": "4.1.1",
-                        "postcss": "5.2.18",
-                        "postcss-modules-extract-imports": "1.2.0",
-                        "postcss-modules-local-by-default": "1.2.0",
-                        "postcss-modules-scope": "1.1.0",
-                        "postcss-modules-values": "1.3.0",
-                        "source-list-map": "0.1.8"
-                    }
-                },
-                "extract-text-webpack-plugin": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
-                    "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
-                    "dev": true,
-                    "requires": {
-                        "async": "2.6.0",
-                        "loader-utils": "1.1.0",
-                        "schema-utils": "0.3.0",
-                        "webpack-sources": "1.1.0"
-                    },
-                    "dependencies": {
-                        "source-list-map": {
-                            "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-                            "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A==",
-                            "dev": true
-                        },
-                        "source-map": {
-                            "version": "0.6.1",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                            "dev": true
-                        },
-                        "webpack-sources": {
-                            "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-                            "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
-                            "dev": true,
-                            "requires": {
-                                "source-list-map": "2.0.0",
-                                "source-map": "0.6.1"
-                            }
-                        }
-                    }
-                },
-                "file-loader": {
-                    "version": "0.8.5",
-                    "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
-                    "integrity": "sha1-knXQMf54DyfUf19K8CvUNxPMFRs=",
-                    "dev": true,
-                    "requires": {
-                        "loader-utils": "0.2.17"
-                    },
-                    "dependencies": {
-                        "loader-utils": {
-                            "version": "0.2.17",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                            "dev": true,
-                            "requires": {
-                                "big.js": "3.2.0",
-                                "emojis-list": "2.1.0",
-                                "json5": "0.5.1",
-                                "object-assign": "4.1.1"
-                            }
-                        }
-                    }
-                },
-                "fs-extra": {
-                    "version": "0.30.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-                    "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "2.4.0",
-                        "klaw": "1.3.1",
-                        "path-is-absolute": "1.0.1",
-                        "rimraf": "2.6.2"
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "isbinaryfile": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-2.0.4.tgz",
-                    "integrity": "sha1-0jWS5qbwk++4TC5hUgVr4pTkFKE=",
-                    "dev": true
-                },
-                "jsonfile": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11"
-                    }
-                },
-                "karma-webpack": {
-                    "version": "1.8.1",
-                    "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-1.8.1.tgz",
-                    "integrity": "sha1-OdX9Lt7qPMPvW0BZibN9Ww5qO04=",
-                    "dev": true,
-                    "requires": {
-                        "async": "0.9.2",
-                        "loader-utils": "0.2.17",
-                        "lodash": "3.10.1",
-                        "source-map": "0.1.43",
-                        "webpack-dev-middleware": "1.12.2"
-                    },
-                    "dependencies": {
-                        "async": {
-                            "version": "0.9.2",
-                            "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                            "dev": true
-                        },
-                        "loader-utils": {
-                            "version": "0.2.17",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                            "dev": true,
-                            "requires": {
-                                "big.js": "3.2.0",
-                                "emojis-list": "2.1.0",
-                                "json5": "0.5.1",
-                                "object-assign": "4.1.1"
-                            }
-                        },
-                        "lodash": {
-                            "version": "3.10.1",
-                            "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                            "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-                            "dev": true
-                        },
-                        "source-map": {
-                            "version": "0.1.43",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                            "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-                            "dev": true,
-                            "requires": {
-                                "amdefine": "1.0.1"
-                            }
-                        }
-                    }
-                },
-                "less-loader": {
-                    "version": "2.2.3",
-                    "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.3.tgz",
-                    "integrity": "sha1-ttj4E5yEk98J2ZKpOgBzSwj4RSg=",
-                    "dev": true,
-                    "requires": {
-                        "loader-utils": "0.2.17"
-                    },
-                    "dependencies": {
-                        "loader-utils": {
-                            "version": "0.2.17",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                            "dev": true,
-                            "requires": {
-                                "big.js": "3.2.0",
-                                "emojis-list": "2.1.0",
-                                "json5": "0.5.1",
-                                "object-assign": "4.1.1"
-                            }
-                        }
-                    }
-                },
-                "mime": {
-                    "version": "1.3.6",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-                    "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-                    "dev": true
-                },
-                "opn": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.1.tgz",
-                    "integrity": "sha1-m9MO4+uk/VM74sg9VjKaTliRO/g=",
-                    "dev": true,
-                    "requires": {
-                        "object-assign": "4.1.1",
-                        "pinkie-promise": "2.0.1"
-                    }
-                },
-                "portfinder": {
-                    "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.9.tgz",
-                    "integrity": "sha1-sayHVdCSr8BDPxxIMvoX1tH12DA=",
-                    "dev": true,
-                    "requires": {
-                        "async": "1.5.2",
-                        "debug": "2.6.9",
-                        "mkdirp": "0.5.1"
-                    },
-                    "dependencies": {
-                        "async": {
-                            "version": "1.5.2",
-                            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-                            "dev": true
-                        }
-                    }
-                },
-                "postcss": {
-                    "version": "5.2.18",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.3.2",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
-                    }
-                },
-                "postcss-loader": {
-                    "version": "0.9.1",
-                    "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-0.9.1.tgz",
-                    "integrity": "sha1-h6PnD1jkbWinW63Gcl2epHc/0dc=",
-                    "dev": true,
-                    "requires": {
-                        "loader-utils": "0.2.17",
-                        "postcss": "5.2.18"
-                    },
-                    "dependencies": {
-                        "loader-utils": {
-                            "version": "0.2.17",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                            "dev": true,
-                            "requires": {
-                                "big.js": "3.2.0",
-                                "emojis-list": "2.1.0",
-                                "json5": "0.5.1",
-                                "object-assign": "4.1.1"
-                            }
-                        }
-                    }
-                },
-                "sass-loader": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-4.1.1.tgz",
-                    "integrity": "sha1-ee+UaM8L9kbClSnh8sumvW5Rx7w=",
-                    "dev": true,
-                    "requires": {
-                        "async": "2.6.0",
-                        "loader-utils": "0.2.17",
-                        "object-assign": "4.1.1"
-                    },
-                    "dependencies": {
-                        "loader-utils": {
-                            "version": "0.2.17",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                            "dev": true,
-                            "requires": {
-                                "big.js": "3.2.0",
-                                "emojis-list": "2.1.0",
-                                "json5": "0.5.1",
-                                "object-assign": "4.1.1"
-                            }
-                        }
-                    }
-                },
-                "sockjs": {
-                    "version": "0.3.18",
-                    "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
-                    "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
-                    "dev": true,
-                    "requires": {
-                        "faye-websocket": "0.10.0",
-                        "uuid": "2.0.3"
-                    }
-                },
-                "sockjs-client": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.1.tgz",
-                    "integrity": "sha1-KEhD6al4TXxHSxVxsyQPyp3aS7A=",
-                    "dev": true,
-                    "requires": {
-                        "debug": "2.6.9",
-                        "eventsource": "0.1.6",
-                        "faye-websocket": "0.11.1",
-                        "inherits": "2.0.3",
-                        "json3": "3.3.2",
-                        "url-parse": "1.2.0"
-                    },
-                    "dependencies": {
-                        "faye-websocket": {
-                            "version": "0.11.1",
-                            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-                            "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-                            "dev": true,
-                            "requires": {
-                                "websocket-driver": "0.7.0"
-                            }
-                        }
-                    }
-                },
-                "source-list-map": {
-                    "version": "0.1.8",
-                    "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
-                    "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
-                    "dev": true
-                },
-                "stylus-loader": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-2.5.1.tgz",
-                    "integrity": "sha1-1a2KfglYrcErhYHnuxabmmHVQhY=",
-                    "dev": true,
-                    "requires": {
-                        "loader-utils": "0.2.17",
-                        "lodash.clonedeep": "4.5.0",
-                        "when": "3.6.4"
-                    },
-                    "dependencies": {
-                        "loader-utils": {
-                            "version": "0.2.17",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                            "dev": true,
-                            "requires": {
-                                "big.js": "3.2.0",
-                                "emojis-list": "2.1.0",
-                                "json5": "0.5.1",
-                                "object-assign": "4.1.1"
-                            }
-                        }
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                },
-                "typescript": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
-                    "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90=",
-                    "dev": true
-                },
-                "uglify-js": {
-                    "version": "2.8.29",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                    "dev": true,
-                    "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
-                    },
-                    "dependencies": {
-                        "yargs": {
-                            "version": "3.10.0",
-                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                            "dev": true,
-                            "requires": {
-                                "camelcase": "1.2.1",
-                                "cliui": "2.1.0",
-                                "decamelize": "1.2.0",
-                                "window-size": "0.1.0"
-                            }
-                        }
-                    }
-                },
-                "url-loader": {
-                    "version": "0.5.9",
-                    "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-                    "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
-                    "dev": true,
-                    "requires": {
-                        "loader-utils": "1.1.0",
-                        "mime": "1.3.6"
-                    }
-                },
-                "uuid": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-                    "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-                    "dev": true
-                },
-                "webpack": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.2.0.tgz",
-                    "integrity": "sha1-CSRjNrVYHJACNT91vK21mKZI+Xc=",
-                    "dev": true,
-                    "requires": {
-                        "acorn": "4.0.13",
-                        "acorn-dynamic-import": "2.0.2",
-                        "ajv": "4.11.8",
-                        "ajv-keywords": "1.5.1",
-                        "async": "2.6.0",
-                        "enhanced-resolve": "3.4.1",
-                        "interpret": "1.0.4",
-                        "json-loader": "0.5.7",
-                        "loader-runner": "2.3.0",
-                        "loader-utils": "0.2.17",
-                        "memory-fs": "0.4.1",
-                        "mkdirp": "0.5.1",
-                        "node-libs-browser": "2.0.0",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3",
-                        "tapable": "0.2.8",
-                        "uglify-js": "2.8.29",
-                        "watchpack": "1.4.0",
-                        "webpack-sources": "0.1.5",
-                        "yargs": "6.6.0"
-                    },
-                    "dependencies": {
-                        "loader-utils": {
-                            "version": "0.2.17",
-                            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                            "dev": true,
-                            "requires": {
-                                "big.js": "3.2.0",
-                                "emojis-list": "2.1.0",
-                                "json5": "0.5.1",
-                                "object-assign": "4.1.1"
-                            }
-                        }
-                    }
-                },
-                "webpack-dev-server": {
-                    "version": "2.2.0-rc.0",
-                    "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.2.0-rc.0.tgz",
-                    "integrity": "sha1-6ooR4hHZUkuJmZRf5WRUgaUf30Y=",
-                    "dev": true,
-                    "requires": {
-                        "chokidar": "1.7.0",
-                        "compression": "1.7.1",
-                        "connect-history-api-fallback": "1.5.0",
-                        "express": "4.16.2",
-                        "http-proxy-middleware": "0.17.4",
-                        "opn": "4.0.2",
-                        "portfinder": "1.0.9",
-                        "serve-index": "1.9.1",
-                        "sockjs": "0.3.18",
-                        "sockjs-client": "1.1.1",
-                        "spdy": "3.4.7",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "3.2.3",
-                        "webpack-dev-middleware": "1.12.2",
-                        "yargs": "6.6.0"
-                    },
-                    "dependencies": {
-                        "opn": {
-                            "version": "4.0.2",
-                            "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-                            "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-                            "dev": true,
-                            "requires": {
-                                "object-assign": "4.1.1",
-                                "pinkie-promise": "2.0.1"
-                            }
-                        }
-                    }
-                },
-                "webpack-merge": {
-                    "version": "2.6.1",
-                    "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-2.6.1.tgz",
-                    "integrity": "sha1-8dgB0sXTn4P/7J8RkkCz476ZShw=",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "4.17.4"
-                    }
-                },
-                "webpack-sources": {
-                    "version": "0.1.5",
-                    "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
-                    "integrity": "sha1-qh86vw8NdNtxEcQOUAuE+WZkB1A=",
-                    "dev": true,
-                    "requires": {
-                        "source-list-map": "0.1.8",
-                        "source-map": "0.5.7"
-                    }
-                },
-                "yargs": {
-                    "version": "6.6.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-                    "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "4.2.1"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                            "dev": true
-                        },
-                        "cliui": {
-                            "version": "3.2.0",
-                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-                            "dev": true,
-                            "requires": {
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wrap-ansi": "2.1.0"
-                            }
-                        }
-                    }
-                },
-                "yargs-parser": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-                    "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "3.0.0"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                            "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
-                            "dev": true
-                        }
-                    }
-                },
-                "zone.js": {
-                    "version": "0.7.8",
-                    "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.7.8.tgz",
-                    "integrity": "sha1-Tz/og01EWX8mOQU6D6Q43zT//e0=",
-                    "dev": true
-                }
-            }
-        },
         "angular2-qrcode": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/angular2-qrcode/-/angular2-qrcode-2.0.1.tgz",
             "integrity": "sha1-G05lwwJpS1B4ygb3ETj35DZ3VNw=",
             "requires": {
                 "qrious": "2.3.0"
-            }
-        },
-        "ansi-escapes": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-            "dev": true
-        },
-        "ansi-gray": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-            "dev": true,
-            "requires": {
-                "ansi-wrap": "0.1.0"
             }
         },
         "ansi-html": {
@@ -2595,12 +1715,6 @@
             "requires": {
                 "color-convert": "1.9.1"
             }
-        },
-        "ansi-wrap": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
-            "dev": true
         },
         "anymatch": {
             "version": "1.3.2",
@@ -2777,12 +1891,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-            "dev": true
-        },
-        "array-differ": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
             "dev": true
         },
         "array-filter": {
@@ -3240,12 +2348,6 @@
             "version": "2.4.3",
             "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
             "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
-        },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-            "dev": true
         },
         "better-assert": {
             "version": "1.0.2",
@@ -4351,27 +3453,6 @@
                 "source-map": "0.5.7"
             }
         },
-        "cli-cursor": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-            "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-            "dev": true,
-            "requires": {
-                "restore-cursor": "1.0.1"
-            }
-        },
-        "cli-spinners": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
-            "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
-            "dev": true
-        },
-        "cli-width": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-            "dev": true
-        },
         "cliui": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -4411,12 +3492,6 @@
                     }
                 }
             }
-        },
-        "clone-stats": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
-            "dev": true
         },
         "co": {
             "version": "4.6.0",
@@ -4481,12 +3556,6 @@
             "requires": {
                 "color-name": "1.1.3"
             }
-        },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true
         },
         "colormin": {
             "version": "1.1.2",
@@ -6518,16 +5587,6 @@
             "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
             "dev": true
         },
-        "dateformat": {
-            "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-            "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-            "dev": true,
-            "requires": {
-                "get-stdin": "4.0.1",
-                "meow": "3.7.0"
-            }
-        },
         "debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -6559,7 +5618,8 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "default-require-extensions": {
             "version": "1.0.0",
@@ -6788,12 +5848,6 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
             "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
-            "dev": true
-        },
-        "diff": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-            "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
             "dev": true
         },
         "diffie-hellman": {
@@ -7132,15 +6186,6 @@
                 "minimalistic-crypto-utils": "1.0.1"
             }
         },
-        "ember-cli-normalize-entity-name": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz",
-            "integrity": "sha1-CxT3vLxZmqEXtf3cgeT9A8S61bc=",
-            "dev": true,
-            "requires": {
-                "silent-error": "1.1.0"
-            }
-        },
         "ember-cli-string-utils": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/ember-cli-string-utils/-/ember-cli-string-utils-1.1.0.tgz",
@@ -7238,12 +6283,6 @@
                 "object-assign": "4.1.1",
                 "tapable": "0.2.8"
             }
-        },
-        "ensure-posix-path": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.0.2.tgz",
-            "integrity": "sha1-pls+QtC3HPxYXrd0+ZQ8jZuRsMI=",
-            "dev": true
         },
         "ent": {
             "version": "2.2.0",
@@ -7546,22 +6585,10 @@
                 "strip-eof": "1.0.0"
             }
         },
-        "exists-sync": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
-            "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
-            "dev": true
-        },
         "exit": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
             "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-            "dev": true
-        },
-        "exit-hook": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
             "dev": true
         },
         "expand-braces": {
@@ -7748,25 +6775,6 @@
                 "object-keys": "1.0.11"
             }
         },
-        "fancy-log": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-            "dev": true,
-            "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
-            },
-            "dependencies": {
-                "time-stamp": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-                    "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-                    "dev": true
-                }
-            }
-        },
         "fast-deep-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
@@ -7781,7 +6789,8 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "fastparse": {
             "version": "1.1.1",
@@ -7796,16 +6805,6 @@
             "dev": true,
             "requires": {
                 "websocket-driver": "0.7.0"
-            }
-        },
-        "figures": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
             }
         },
         "file-loader": {
@@ -7905,30 +6904,6 @@
             "requires": {
                 "path-exists": "2.1.0",
                 "pinkie-promise": "2.0.1"
-            }
-        },
-        "findup": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
-            "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
-            "dev": true,
-            "requires": {
-                "colors": "0.6.2",
-                "commander": "2.1.0"
-            },
-            "dependencies": {
-                "colors": {
-                    "version": "0.6.2",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-                    "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-                    "dev": true
-                },
-                "commander": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-                    "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E=",
-                    "dev": true
-                }
             }
         },
         "flatten": {
@@ -9295,15 +8270,6 @@
                 }
             }
         },
-        "glogg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
-            }
-        },
         "graceful-fs": {
             "version": "4.1.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -9315,114 +8281,6 @@
             "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
             "dev": true
-        },
-        "gulp-util": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-            "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
-            "dev": true,
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "1.0.12",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.3.3",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.0.3",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "5.1.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "2.3.3",
-                        "xtend": "4.0.1"
-                    }
-                }
-            }
-        },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
-            "requires": {
-                "glogg": "1.0.1"
-            }
         },
         "handle-thing": {
             "version": "1.2.5",
@@ -9572,15 +8430,6 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
-        },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
-            }
         },
         "has-unicode": {
             "version": "2.0.1",
@@ -10082,7 +8931,8 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz",
             "integrity": "sha1-W//LEZetPoEFD44X4hZoCH7p6y8=",
-            "dev": true
+            "dev": true,
+            "optional": true
         },
         "inflight": {
             "version": "1.0.6",
@@ -10120,54 +8970,6 @@
             "dev": true,
             "requires": {
                 "source-map": "0.5.7"
-            }
-        },
-        "inquirer": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-            "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-            "dev": true,
-            "requires": {
-                "ansi-escapes": "1.4.0",
-                "ansi-regex": "2.1.1",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.2.0",
-                "figures": "1.7.0",
-                "lodash": "4.17.4",
-                "readline2": "1.0.1",
-                "run-async": "0.1.0",
-                "rx-lite": "3.1.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
             }
         },
         "insert-module-globals": {
@@ -10729,136 +9531,6 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
-        "istanbul": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.3.tgz",
-            "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
-            "dev": true,
-            "requires": {
-                "abbrev": "1.0.9",
-                "async": "1.5.2",
-                "escodegen": "1.8.1",
-                "esprima": "2.7.3",
-                "fileset": "0.2.1",
-                "handlebars": "4.0.11",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "once": "1.4.0",
-                "resolve": "1.1.7",
-                "supports-color": "3.2.3",
-                "which": "1.3.0",
-                "wordwrap": "1.0.0"
-            },
-            "dependencies": {
-                "abbrev": {
-                    "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                    "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-                    "dev": true
-                },
-                "async": {
-                    "version": "1.5.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-                    "dev": true
-                },
-                "escodegen": {
-                    "version": "1.8.1",
-                    "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-                    "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-                    "dev": true,
-                    "requires": {
-                        "esprima": "2.7.3",
-                        "estraverse": "1.9.3",
-                        "esutils": "2.0.2",
-                        "optionator": "0.8.2",
-                        "source-map": "0.2.0"
-                    }
-                },
-                "esprima": {
-                    "version": "2.7.3",
-                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                    "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-                    "dev": true
-                },
-                "estraverse": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                    "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-                    "dev": true
-                },
-                "fileset": {
-                    "version": "0.2.1",
-                    "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.2.1.tgz",
-                    "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
-                    "dev": true,
-                    "requires": {
-                        "glob": "5.0.15",
-                        "minimatch": "2.0.10"
-                    }
-                },
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "2.0.10",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-                    "dev": true
-                },
-                "minimatch": {
-                    "version": "2.0.10",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-                    "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-                    "dev": true,
-                    "requires": {
-                        "brace-expansion": "1.1.8"
-                    }
-                },
-                "resolve": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-                    "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "amdefine": "1.0.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "1.0.0"
-                    }
-                },
-                "wordwrap": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                    "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-                    "dev": true
-                }
-            }
-        },
         "istanbul-api": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
@@ -11124,6 +9796,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "jsonify": "0.0.0"
             }
@@ -11376,15 +10049,6 @@
                 "source-map-support": "0.4.18"
             }
         },
-        "karma-sourcemap-loader": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
-            "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "4.1.11"
-            }
-        },
         "karma-spec-reporter": {
             "version": "0.0.32",
             "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.32.tgz",
@@ -11446,15 +10110,6 @@
             "dev": true,
             "requires": {
                 "is-buffer": "1.1.6"
-            }
-        },
-        "klaw": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-            "dev": true,
-            "requires": {
-                "graceful-fs": "4.1.11"
             }
         },
         "labeled-stream-splicer": {
@@ -11685,6 +10340,7 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "prelude-ls": "1.1.2",
                 "type-check": "0.3.2"
@@ -11826,60 +10482,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
             "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-            "dev": true
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-            "dev": true
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-            "dev": true
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-            "dev": true
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-            "dev": true
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-            "dev": true
-        },
         "lodash.assign": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -11898,38 +10500,6 @@
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true,
-            "requires": {
-                "lodash._root": "3.0.1"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true,
-            "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
-            }
-        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11942,44 +10512,11 @@
             "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU=",
             "dev": true
         },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
-        },
         "lodash.tail": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
             "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
             "dev": true
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "dev": true,
-            "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "dev": true,
-            "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
-            }
         },
         "lodash.uniq": {
             "version": "4.5.0",
@@ -12444,15 +10981,6 @@
                 "object-visit": "1.0.1"
             }
         },
-        "matcher-collection": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
-            "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-            "dev": true,
-            "requires": {
-                "minimatch": "3.0.4"
-            }
-        },
         "math-expression-evaluator": {
             "version": "1.2.17",
             "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -12901,44 +11429,6 @@
             "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
             "dev": true
         },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "0.0.2"
-            },
-            "dependencies": {
-                "duplexer2": {
-                    "version": "0.0.2",
-                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-                    "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.1.14"
-                    }
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                }
-            }
-        },
-        "mute-stream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-            "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-            "dev": true
-        },
         "nan": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
@@ -13131,69 +11621,6 @@
             "resolved": "https://registry.npmjs.org/node-modules-path/-/node-modules-path-1.0.1.tgz",
             "integrity": "sha1-QAlrCM560OoUaAhjr0ScfHWl0cg=",
             "dev": true
-        },
-        "node-sass": {
-            "version": "4.5.3",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
-            "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
-            "dev": true,
-            "requires": {
-                "async-foreach": "0.1.3",
-                "chalk": "1.1.3",
-                "cross-spawn": "3.0.1",
-                "gaze": "1.1.2",
-                "get-stdin": "4.0.1",
-                "glob": "7.0.5",
-                "in-publish": "2.0.0",
-                "lodash.assign": "4.2.0",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.mergewith": "4.6.0",
-                "meow": "3.7.0",
-                "mkdirp": "0.5.1",
-                "nan": "2.7.0",
-                "node-gyp": "3.6.2",
-                "npmlog": "4.1.2",
-                "request": "2.83.0",
-                "sass-graph": "2.2.4",
-                "stdout-stream": "1.4.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "cross-spawn": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-                    "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "4.1.1",
-                        "which": "1.3.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
         },
         "nodemailer": {
             "version": "2.7.2",
@@ -13530,12 +11957,6 @@
                 "wrappy": "1.0.2"
             }
         },
-        "onetime": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-            "dev": true
-        },
         "opn": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
@@ -13568,6 +11989,7 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "deep-is": "0.1.3",
                 "fast-levenshtein": "2.0.6",
@@ -13581,7 +12003,8 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
                     "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -13590,45 +12013,6 @@
             "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
             "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
             "dev": true
-        },
-        "ora": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
-            "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-spinners": "0.1.2",
-                "object-assign": "4.1.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
         },
         "original": {
             "version": "1.0.0",
@@ -16496,17 +14880,6 @@
                 }
             }
         },
-        "readline2": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-            "dev": true,
-            "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "mute-stream": "0.0.5"
-            }
-        },
         "recast": {
             "version": "0.10.43",
             "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
@@ -16672,57 +15045,6 @@
             "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
             "dev": true
         },
-        "remap-istanbul": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.6.4.tgz",
-            "integrity": "sha1-rFUe/xqmQVBLTzGNAwPdph47tpU=",
-            "dev": true,
-            "requires": {
-                "amdefine": "1.0.0",
-                "gulp-util": "3.0.7",
-                "istanbul": "0.4.3",
-                "source-map": "0.5.7",
-                "through2": "2.0.1"
-            },
-            "dependencies": {
-                "amdefine": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
-                    "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
-                    "dev": true
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "through2": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-                    "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "2.0.6",
-                        "xtend": "4.0.1"
-                    }
-                }
-            }
-        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -16770,12 +15092,6 @@
             "requires": {
                 "is-finite": "1.0.2"
             }
-        },
-        "replace-ext": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-            "dev": true
         },
         "request": {
             "version": "2.83.0",
@@ -16881,16 +15197,6 @@
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
             "dev": true
         },
-        "restore-cursor": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-            "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-            "dev": true,
-            "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
-            }
-        },
         "right-align": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -16975,21 +15281,6 @@
                 }
             }
         },
-        "rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
-            "dev": true
-        },
-        "run-async": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-            "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-            "dev": true,
-            "requires": {
-                "once": "1.4.0"
-            }
-        },
         "run-queue": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -16998,12 +15289,6 @@
             "requires": {
                 "aproba": "1.2.0"
             }
-        },
-        "rx-lite": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-            "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-            "dev": true
         },
         "rxjs": {
             "version": "5.5.6",
@@ -17079,15 +15364,6 @@
             "dev": true,
             "requires": {
                 "ajv": "5.3.0"
-            }
-        },
-        "script-loader": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/script-loader/-/script-loader-0.7.2.tgz",
-            "integrity": "sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==",
-            "dev": true,
-            "requires": {
-                "raw-loader": "0.5.1"
             }
         },
         "scryptsy": {
@@ -17709,46 +15985,6 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
-        "source-map-loader": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.1.6.tgz",
-            "integrity": "sha1-wJkD2m1zueU7ftjuUkVZcFHpjpE=",
-            "dev": true,
-            "requires": {
-                "async": "0.9.2",
-                "loader-utils": "0.2.17",
-                "source-map": "0.1.43"
-            },
-            "dependencies": {
-                "async": {
-                    "version": "0.9.2",
-                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
-                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
-                    "dev": true
-                },
-                "loader-utils": {
-                    "version": "0.2.17",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
-                    }
-                },
-                "source-map": {
-                    "version": "0.1.43",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-                    "dev": true,
-                    "requires": {
-                        "amdefine": "1.0.1"
-                    }
-                }
-            }
-        },
         "source-map-resolve": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
@@ -17774,37 +16010,6 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
-        },
-        "sourcemap-istanbul-instrumenter-loader": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/sourcemap-istanbul-instrumenter-loader/-/sourcemap-istanbul-instrumenter-loader-0.2.0.tgz",
-            "integrity": "sha1-j9cuir0W3tWJGKdHTbW7PQ27ys0=",
-            "dev": true,
-            "requires": {
-                "istanbul": "0.4.3",
-                "loader-utils": "0.2.17",
-                "object-assign": "4.1.1"
-            },
-            "dependencies": {
-                "loader-utils": {
-                    "version": "0.2.17",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-                    "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
-                    }
-                }
-            }
-        },
-        "sparkles": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
             "dev": true
         },
         "spdx-correct": {
@@ -18521,24 +16726,6 @@
                 "block-stream": "0.0.9",
                 "fstream": "1.0.11",
                 "inherits": "2.0.3"
-            }
-        },
-        "temp": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
-            "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
-            "dev": true,
-            "requires": {
-                "os-tmpdir": "1.0.2",
-                "rimraf": "2.2.8"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.2.8",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-                    "dev": true
-                }
             }
         },
         "through": {
@@ -19521,17 +17708,6 @@
                 "extsprintf": "1.3.0"
             }
         },
-        "vinyl": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-            "dev": true,
-            "requires": {
-                "clone": "1.0.3",
-                "clone-stats": "0.0.1",
-                "replace-ext": "0.0.1"
-            }
-        },
         "vlq": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
@@ -19552,16 +17728,6 @@
             "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
             "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
             "dev": true
-        },
-        "walk-sync": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.2.7.tgz",
-            "integrity": "sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=",
-            "dev": true,
-            "requires": {
-                "ensure-posix-path": "1.0.2",
-                "matcher-collection": "1.0.5"
-            }
         },
         "watchpack": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@ionic/app-scripts": "3.1.8",
     "@types/jasmine": "^2.8.6",
     "@types/node": "^8.9.4",
-    "angular-cli": "^1.0.0-beta.28.3",
     "connect": "^3.6.5",
     "ionic-mocks": "^1.2.1",
     "jasmine-core": "2.99.1",


### PR DESCRIPTION
The reference was useless and caused some warnings.

FYI: the package "angular-cli" has been replaced a long time ago by "@angular/cli".

