### PR TITLE
Make wallet labels unique & fix bugs

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -215,6 +215,7 @@
     "IMPORT_WALLET": "Importiere Wallet",
     "KEEP_SAFE": "Sichere es",
     "LABEL": "Bezeichnung",
+    "LABEL_EXISTS": "Es existiert bereits ein Wallet mit der Bezeichnung '{{ label }}'!",
     "MY_WALLET": "Mein Wallet",
     "NEW_WALLET_NAME": "Neuer Wallet Name",
     "NO_TRANSACTIONS": "Keine Transaktionen verfügbar",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -217,6 +217,7 @@
     "IMPORT_WALLET": "Import Wallet",
     "KEEP_SAFE": "Keep Safe",
     "LABEL": "Label",
+    "LABEL_EXISTS": "There is already a wallet with the label '{{ label }}'!",
     "MY_WALLET": "My Wallet",
     "NEW_WALLET_NAME": "New wallet name",
     "NO_TRANSACTIONS": "No transactions available",

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.html
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.html
@@ -4,7 +4,7 @@
     <button ion-button icon-only menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>
-    <ion-title>{{ wallet?.address | accountLabel: 'WALLETS_PAGE.MY_WALLET' | translate }}</ion-title>
+    <ion-title>{{ wallet?.username || wallet?.label || ('WALLETS_PAGE.MY_WALLET' | translate) }}</ion-title>
     <ion-buttons end>
       <button ion-button icon-only (click)="presentWalletActionSheet()">
         <ion-icon name="md-more"></ion-icon>

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -259,8 +259,8 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
     const modal = this.modalCtrl.create('SetLabelPage', {'label': this.wallet.label}, {cssClass: 'inset-modal-tiny'});
 
     modal.onDidDismiss((label) => {
-      const labelExists = this.userDataProvider.setWalletLabel(this.wallet, label);
-      if (labelExists) {
+      const isLabelUnique = this.userDataProvider.setWalletLabel(this.wallet, label);
+      if (isLabelUnique === false) {
         this.toastProvider.error({key: 'WALLETS_PAGE.LABEL_EXISTS', parameters: {label: label}} as TranslatableObject, 3000);
       }
     });

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -32,6 +32,7 @@ import { PinCodeComponent } from '@components/pin-code/pin-code';
 import { ConfirmTransactionComponent } from '@components/confirm-transaction/confirm-transaction';
 import { Clipboard } from '@ionic-native/clipboard';
 import { ToastProvider } from '@providers/toast/toast';
+import { TranslatableObject } from '@models/translate';
 
 @IonicPage()
 @Component({
@@ -255,13 +256,13 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
   }
 
   presentLabelModal() {
-    const modal = this.modalCtrl.create('SetLabelPage', {'label': this.wallet.label }, { cssClass: 'inset-modal-tiny' });
+    const modal = this.modalCtrl.create('SetLabelPage', {'label': this.wallet.label}, {cssClass: 'inset-modal-tiny'});
 
-    modal.onDidDismiss((data) => {
-      if (lodash.isEmpty(data)) { return; }
-
-      this.zone.run(() => this.wallet.label = data);
-      this.saveWallet();
+    modal.onDidDismiss((label) => {
+      const labelExists = this.userDataProvider.setWalletLabel(this.wallet, label);
+      if (labelExists) {
+        this.toastProvider.error({key: 'WALLETS_PAGE.LABEL_EXISTS', parameters: {label: label}} as TranslatableObject, 3000);
+      }
     });
 
     modal.present();

--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -32,7 +32,7 @@
             <ion-item class="wallet">
               <ion-label [ngClass]="{delegate: wallet?.isDelegate, normal: !wallet?.isDelegate}">
                 <h2 class="amount">{{ currentNetwork?.symbol }} {{ wallet?.balance | unitsSatoshi }}</h2>
-                <p class="address">{{ wallet?.address | accountLabel | truncateMiddle: 15 }}</p>
+                <p class="address">{{ (wallet?.username || wallet?.label || wallet?.address) | truncateMiddle: 15 }}</p>
                 <ion-badge class="watch-only-badge" [color]="wallet?.isDelegate ? 'primary' : 'danger-alternative'" *ngIf="wallet.isWatchOnly">
                   {{ 'WATCH_ONLY' | translate }}
                 </ion-badge>

--- a/src/providers/contacts-auto-complete/contacts-auto-complete.ts
+++ b/src/providers/contacts-auto-complete/contacts-auto-complete.ts
@@ -31,7 +31,7 @@ export class ContactsAutoCompleteService implements AutoCompleteService {
 
     const wallets: AutoCompleteContact[] = lodash.map(this.userDataProvider.currentProfile.wallets, (wallet: Wallet) => {
       const address = wallet.address;
-      const label = this.userDataProvider.getWalletLabel(wallet);
+      const label = this.userDataProvider.getWalletLabel(wallet) || wallet.address;
       if (address) {
         return {
           address: address,

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -207,6 +207,21 @@ export class UserDataProvider {
     return this.saveProfiles();
   }
 
+  public setWalletLabel(wallet: Wallet, label: string): boolean {
+    if (!wallet || wallet.label === label) {
+      return;
+    }
+
+    const exists = lodash.some(this.currentProfile.wallets, w => label && w.label && w.label.toLowerCase() === label.toLowerCase());
+
+    if (exists) {
+      return true;
+    }
+
+    wallet.label = label;
+    this.saveWallet(wallet);
+  }
+
   public getWalletLabel(walletOrAddress: Wallet | string): string {
     let wallet: Wallet;
     if (typeof walletOrAddress === 'string') {
@@ -219,7 +234,7 @@ export class UserDataProvider {
       return null;
     }
 
-    return wallet.username || wallet.label || wallet.address;
+    return wallet.username || wallet.label;
   }
 
   setCurrentWallet(wallet: Wallet) {

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -215,11 +215,12 @@ export class UserDataProvider {
     const exists = lodash.some(this.currentProfile.wallets, w => label && w.label && w.label.toLowerCase() === label.toLowerCase());
 
     if (exists) {
-      return true;
+      return false;
     }
 
     wallet.label = label;
     this.saveWallet(wallet);
+    return true;
   }
 
   public getWalletLabel(walletOrAddress: Wallet | string): string {


### PR DESCRIPTION
- make wallet labels unique (case insensitive)
- fix bug that wallet label was not updated "on same screen" (problem was that we used the accountLabelPipe with the wallet address, which didn't change and therefore the label stayed the same)
  - also don't use pipe if we KNOW we have a wallet => it's unnecessary (+fixes the not update fix)
- fix bug that "address" was returned for wallets when the accountLabelPipe was used (made the "fallback label" useless)
- remove `this.zone.run` statement - don't see a reason to use it there - or did I miss something?

I just wanted to make the wallet label unique, but came on some bugs (maybe even introduced by me in earlier commits) on the way :P