### PR TITLE
Generate passphrase - word confirmation : remove default values for dev net

### DIFF
--- a/src/modals/wallet-backup/wallet-backup.ts
+++ b/src/modals/wallet-backup/wallet-backup.ts
@@ -82,7 +82,7 @@ export class WalletBackupModal {
         const randomWord: string = words[randomIndex];
         randomWords.push(new PassphraseWord(randomWord,
                                             randomIndex + 1,
-                                            this.userDataProvider.isDevNet ? randomWord : null));
+                                            null));
       }
     }
 


### PR DESCRIPTION
On dev net when we generate a new passphrase and go to the word confirmation screen, we already have the 3 words defaulted to the correct value from passphrase.

I understand it helps win some time, but I think we shouldn't have a different behaviour for this between dev and main net, by doing that we are skipping the "user input" step and may miss bugs or be confused by the different behaviour... Typically I thought this was a general bug and understood by reading the code that it was only on dev net and not main net.

But it's a suggestion, I let you decide what you think is better 😉 