### PR TITLE
Escape html in address dropdown

### DIFF
--- a/src/pages/transaction/transaction-send/transaction-send.html
+++ b/src/pages/transaction/transaction-send/transaction-send.html
@@ -20,8 +20,8 @@
               <span class="auto-complete-row">
                 <ion-icon [name]="attrs.data.iconName" item-start></ion-icon>
                 <span>
-                  <span [innerHTML]="attrs.data.name | boldprefix:attrs.keyword"></span>
-                  <span class="autocomplete-second-line" [innerHTML]="attrs.data.address | boldprefix:attrs.keyword"></span>
+                  <span [innerHTML]="attrs.data.name | escapeHTML | boldprefix:attrs.keyword"></span>
+                  <span class="autocomplete-second-line" [innerHTML]="attrs.data.address | escapeHTML | boldprefix:attrs.keyword"></span>
                 </span>
                 </span>
             </ng-template>

--- a/src/pipes/escape-html/escape-html.ts
+++ b/src/pipes/escape-html/escape-html.ts
@@ -1,0 +1,20 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'escapeHTML'
+})
+export class EscapeHTMLPipe implements PipeTransform {
+  transform(htmlString: string): string {
+    if (!htmlString) {
+      return htmlString;
+    }
+    return htmlString.replace(/[&"<>]/g, function (c) {
+        return {
+            '&': '&amp;',
+            '"': '&quot;',
+            '<': '&lt;',
+            '>': '&gt;'
+        }[c];
+    });
+  }
+}

--- a/src/pipes/pipes.module.ts
+++ b/src/pipes/pipes.module.ts
@@ -3,6 +3,7 @@ import { TruncateMiddlePipe } from './../pipes/truncate-middle/truncate-middle';
 import { UnitsSatoshiPipe } from './../pipes/units-satoshi/units-satoshi';
 import { MarketNumberPipe } from './../pipes/market-number/market-number';
 import { AccountLabelPipe } from './../pipes/account-label/account-label';
+import { EscapeHTMLPipe } from './../pipes/escape-html/escape-html';
 import { HasAccountLabelPipe } from './../pipes/has-account-label/has-account-label';
 import { TranslateCutPipe } from './../pipes/translate-cut/translate-cut';
 import { TimestampHumanPipe } from './timestamp-human/timestamp-human';
@@ -15,6 +16,7 @@ import { SecondsToTimePipe } from './seconds-to-time/seconds-to-time';
     MarketNumberPipe,
     AccountLabelPipe,
     HasAccountLabelPipe,
+    EscapeHTMLPipe,
     TimestampHumanPipe,
     TimezonePipe,
     SecondsToTimePipe,
@@ -24,6 +26,7 @@ import { SecondsToTimePipe } from './seconds-to-time/seconds-to-time';
     UnitsSatoshiPipe,
     MarketNumberPipe,
     AccountLabelPipe,
+    EscapeHTMLPipe,
     HasAccountLabelPipe,
     TimestampHumanPipe,
     TimezonePipe,


### PR DESCRIPTION
The dropdown containing addresses makes use of [innerHTML] and just shows whatever it is fed, including all kinds of html. This is needed to show the bold text when searching for a contact, but it can also result in unwanted behaviour as shown in the screenshot below:

![contacts-image](https://user-images.githubusercontent.com/35610748/37548458-58528b0c-2978-11e8-9fa2-d8563acb3204.jpg)

To counter this, I've added an EscapeHTML pipe that is called first on the address value that is retrieved. Afterwards, the boldprefix pipe is used to ensure that the bold text can still be used to highlight matches (as I assumed that was done in HTML and we don't want to escape that). This results in the following:

![contacts-escaped](https://user-images.githubusercontent.com/35610748/37548483-8cb1b74c-2978-11e8-8316-3c3866ead5f6.jpg)
