### PR TITLE
Consistent ui behavior in send page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,7 +17,7 @@ import { MarketDataProvider } from '@providers/market-data/market-data';
 import { SettingsDataProvider } from '@providers/settings-data/settings-data';
 import { ToastProvider } from '@providers/toast/toast';
 import { ForgeProvider } from '@providers/forge/forge';
-import { ContactsAutoCompleteService } from '@providers/contacts-auto-complete/contacts-auto-complete';
+import { AccountAutoCompleteService } from '@providers/account-auto-complete/account-auto-complete';
 
 // Ionic native
 import { SplashScreen } from '@ionic-native/splash-screen';
@@ -78,7 +78,7 @@ export function httpLoaderFactory(http: HttpClient) {
     SettingsDataProvider,
     ForgeProvider,
     ToastProvider,
-    ContactsAutoCompleteService,
+    AccountAutoCompleteService,
     NeoApiProvider,
     AddressCheckerProvider
   ]

--- a/src/assets/i18n/bg.json
+++ b/src/assets/i18n/bg.json
@@ -161,7 +161,7 @@
     "ADD_ADDRESS_TO_CONTACTS": "Добави {{ address }} към контактите",
     "AMOUNT": "Сума",
     "CONFIRMATIONS": "Потвърждения",
-    "CONTACT_NAME": "Ново име за Контакта (не е задължително)",
+    "NEW_CONTACT_NAME": "Ново име за Контакта (не е задължително)",
     "COPY_TXID": "Копирай TXID",
     "CREATE_TRANSACTION_ERROR": "Грешка при създаването на транзакцията. Проверете връзката към Интернет",
     "DELEGATE_REGISTRATION": "Регистриране на Делегат",

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -164,7 +164,10 @@
     "ADD_ADDRESS_TO_CONTACTS": "Füge {{ address }} zu Kontakten hinzu",
     "AMOUNT": "Anzahl",
     "CONFIRMATIONS": "Bestätigungen",
-    "CONTACT_NAME": "Neuer Kontakt Name (optional)",
+    "NEW_CONTACT_NAME": "Neuer Kontakt Name (optional)",
+    "NEW_WALLET_LABEL": "Wallet Bezeichnung (optional)",
+    "EXISTING_WALLET": "Wallet",
+    "EXISTING_CONTACT": "Kontakt",
     "COPY_TXID": "Kopiere TXID",
     "CREATE_TRANSACTION_ERROR": "Konnte Transaktion nicht erstellen, prüfe die Internetverbindung",
     "DELEGATE_REGISTRATION": "Delegate Registration",
@@ -203,7 +206,9 @@
     "INVALID_ADDRESS": "Diese Adresse ist ungültig!",
     "IS_OWN_ADDRESS": "Dies ist deine eigene Adresse. Bist du sicher, dass du an deine eigene Adresse senden möchtest?",
     "NO_TRANSACTIONS": "Es scheint so als hätte diese Adresse keine Transaktionen. Bist du sicher, dass sie korrekt ist?",
-    "IS_NEO_ADDRESS": "Es sieht so aus, als wäre dies eine 'NEO' Adresse. Bist du sicher, dass sie korrekt ist?"
+    "IS_NEO_ADDRESS": "Es sieht so aus, als wäre dies eine 'NEO' Adresse. Bist du sicher, dass sie korrekt ist?",
+    "LABEL_EXISTS": "Es existiert bereits ein Wallet mit der Bezeichnung '{{ label }}'!",
+    "INVALID_WALLET": "Das Wallet ist ungültig!"
   },
   "WALLETS_PAGE": {
     "ADD_WALLET_ERROR": "Konnte Wallet nicht hinzufügen",
@@ -227,7 +232,6 @@
     "IMPORT_WALLET": "Importiere Wallet",
     "KEEP_SAFE": "Sichere es",
     "LABEL": "Bezeichnung",
-    "LABEL_EXISTS": "Es existiert bereits ein Wallet mit der Bezeichnung '{{ label }}'!",
     "MY_WALLET": "Mein Wallet",
     "NEW_WALLET_NAME": "Neuer Wallet Name",
     "NO_TRANSACTIONS": "Keine Transaktionen verfügbar",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -165,7 +165,10 @@
     "ADD_ADDRESS_TO_CONTACTS": "Add {{ address }} to contacts",
     "AMOUNT": "Amount",
     "CONFIRMATIONS": "Confirmations",
-    "CONTACT_NAME": "New Contact's Name (optional)",
+    "NEW_CONTACT_NAME": "New Contact's Name (optional)",
+    "NEW_WALLET_LABEL": "Wallet label (optional)",
+    "EXISTING_WALLET": "Wallet",
+    "EXISTING_CONTACT": "Contact",
     "COPY_TXID": "Copy TXID",
     "CREATE_TRANSACTION_ERROR": "Could not create transaction. Check internet connectivity",
     "DELEGATE_REGISTRATION": "Delegate Registration",
@@ -204,7 +207,9 @@
     "INVALID_ADDRESS": "This address is invalid!",
     "IS_OWN_ADDRESS": "This is your own address. Are you sure you want to send to your own address?",
     "NO_TRANSACTIONS": "It appears the address doesn't have any transactions. Are you sure it's correct?",
-    "IS_NEO_ADDRESS": "It looks like this is a 'NEO' address. Are you sure it's correct?"
+    "IS_NEO_ADDRESS": "It looks like this is a 'NEO' address. Are you sure it's correct?",
+    "LABEL_EXISTS": "There is already a wallet with the label '{{ label }}'!",
+    "INVALID_WALLET": "The wallet is invalid or not set!"
   },
   "WALLETS_PAGE": {
     "ADD_WALLET_ERROR": "Could not add wallet",
@@ -228,7 +233,6 @@
     "IMPORT_WALLET": "Import Wallet",
     "KEEP_SAFE": "Keep Safe",
     "LABEL": "Label",
-    "LABEL_EXISTS": "There is already a wallet with the label '{{ label }}'!",
     "MY_WALLET": "My Wallet",
     "NEW_WALLET_NAME": "New wallet name",
     "NO_TRANSACTIONS": "No transactions available",

--- a/src/assets/i18n/gr.json
+++ b/src/assets/i18n/gr.json
@@ -152,7 +152,7 @@
     "ADD_ADDRESS_TO_CONTACTS": "Πρόσθεση {{ address }} στις επαφές",
     "AMOUNT": "Ποσό",
     "CONFIRMATIONS": "Επιβεβαιώσεις",
-    "CONTACT_NAME": "Όνομα νέας επαφής (προαιρετικό)",
+    "NEW_CONTACT_NAME": "Όνομα νέας επαφής (προαιρετικό)",
     "COPY_TXID": "Αντιγραφή TXID",
     "CREATE_TRANSACTION_ERROR": "Αδυναμία δημιουργίας συναλλαγής, ελέγξτε την σύνδεσή σας στο δίκτυο",
     "DELEGATE_REGISTRATION": "Καταχώρηση Αντιπροσώπου",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -152,7 +152,7 @@
     "ADD_ADDRESS_TO_CONTACTS": "Aggiungi {{ address }} ai contatti",
     "AMOUNT": "Somma",
     "CONFIRMATIONS": "Conferme",
-    "CONTACT_NAME": "Nome Nuovo Contatto (opzionale)",
+    "NEW_CONTACT_NAME": "Nome Nuovo Contatto (opzionale)",
     "COPY_TXID": "Copia TXID",
     "CREATE_TRANSACTION_ERROR": "Impossibile creare una transazione. Controlla la connettività Internet",
     "DELEGATE_REGISTRATION": "Registrazione Delegato",

--- a/src/assets/i18n/kor.json
+++ b/src/assets/i18n/kor.json
@@ -163,7 +163,7 @@
     "ADD_ADDRESS_TO_CONTACTS": "{{ address }} 를 연락처에 추가",
     "AMOUNT": "수량",
     "CONFIRMATIONS": "컨펌",
-    "CONTACT_NAME": "새로운 연락처 이름 (선택)",
+    "NEW_CONTACT_NAME": "새로운 연락처 이름 (선택)",
     "COPY_TXID": "트랜잭션ID 복사",
     "CREATE_TRANSACTION_ERROR": "트랜잭션을 생성하지 못했습니다. 인터넷 연결을 확인하세요.",
     "DELEGATE_REGISTRATION": "대표자 등록",

--- a/src/assets/i18n/nl.json
+++ b/src/assets/i18n/nl.json
@@ -164,7 +164,7 @@
     "ADD_ADDRESS_TO_CONTACTS": "Voeg {{ address }} toe aan contacten",
     "AMOUNT": "Bedrag",
     "CONFIRMATIONS": "Bevestigingen",
-    "CONTACT_NAME": "Nieuwe contact naam (Optioneel)",
+    "NEW_CONTACT_NAME": "Nieuwe contact naam (Optioneel)",
     "COPY_TXID": "Kopieer TXID",
     "CREATE_TRANSACTION_ERROR": "Kon transactie niet aanmaken. Controleer je internet verbinding",
     "DELEGATE_REGISTRATION": "Registratie Afgevaardigde",

--- a/src/assets/i18n/pt-br.json
+++ b/src/assets/i18n/pt-br.json
@@ -153,7 +153,7 @@
       "ADD_ADDRESS_TO_CONTACTS": "Adicionar {{ address }} aos contatos",
       "AMOUNT": "Montante",
       "CONFIRMATIONS": "Confirmações",
-      "CONTACT_NAME": "Novo nome do contato (optional)",
+      "NEW_CONTACT_NAME": "Novo nome do contato (optional)",
       "COPY_TXID": "Copiar TXID",
       "CREATE_TRANSACTION_ERROR": "Não foi possível criar transações. Verifique a conexão com a internet.",
       "DELEGATE_REGISTRATION": "Delegado registrado",

--- a/src/assets/i18n/ru.json
+++ b/src/assets/i18n/ru.json
@@ -144,7 +144,7 @@
     "ADD_ADDRESS_TO_CONTACTS": "Добавлять {{ address }} в контакты",
     "AMOUNT": "Сумма",
     "CONFIRMATIONS": "Подтверждения",
-    "CONTACT_NAME": "Имя нового контакта (optional)",
+    "NEW_CONTACT_NAME": "Имя нового контакта (optional)",
     "COPY_TXID": "Копия TXID",
     "CREATE_TRANSACTION_ERROR": "Не удалось создать транзакцию. Проверти соединение к интернету",
     "DELEGATE_REGISTRATION": "Регистрация Делегата",

--- a/src/assets/i18n/sv.json
+++ b/src/assets/i18n/sv.json
@@ -152,7 +152,7 @@
     "ADD_ADDRESS_TO_CONTACTS": "Lägg till {{ address }} till kontakter",
     "AMOUNT": "Belopp",
     "CONFIRMATIONS": "Bekräftelser",
-    "CONTACT_NAME": "Nya Kontaktens Namn (frivilligt)",
+    "NEW_CONTACT_NAME": "Nya Kontaktens Namn (frivilligt)",
     "COPY_TXID": "Kopiera TXID",
     "CREATE_TRANSACTION_ERROR": "Kunde ej skapa transaktion. Kolla din uppkoppling mot Internet",
     "DELEGATE_REGISTRATION": "Registrera Delegat",

--- a/src/models/contact.ts
+++ b/src/models/contact.ts
@@ -5,10 +5,16 @@ export interface AddressMap {
   highlight?: boolean;
 }
 
-export interface AutoCompleteContact {
+export enum AutoCompleteAccountType {
+  Wallet,
+  Contact
+}
+
+export interface AutoCompleteAccount {
   address: string;
   name: string;
   iconName: string;
+  type: AutoCompleteAccountType;
 }
 
 export interface Contact {

--- a/src/pages/transaction/transaction-send/transaction-send.html
+++ b/src/pages/transaction/transaction-send/transaction-send.html
@@ -43,13 +43,19 @@
           </ion-item>
         </ion-col>
       </ion-row>
-      <ion-row *ngIf="!isExistingContact">
+      <ion-row *ngIf="transaction.recipientAddress">
         <ion-col>
           <ion-item>
-            <ion-label stacked>{{ 'TRANSACTIONS_PAGE.CONTACT_NAME' | translate }}</ion-label>
+            <ion-label stacked [ngSwitch]="addressType">
+              <ng-container *ngSwitchCase="addressTypes.Unknown">{{ 'TRANSACTIONS_PAGE.NEW_CONTACT_NAME' | translate }}</ng-container>
+              <ng-container *ngSwitchCase="addressTypes.WalletWithoutLabel">{{ 'TRANSACTIONS_PAGE.NEW_WALLET_LABEL' | translate }}</ng-container>
+              <ng-container *ngSwitchCase="addressTypes.WalletWithLabel">{{ 'TRANSACTIONS_PAGE.EXISTING_WALLET' | translate }}</ng-container>
+              <ng-container *ngSwitchCase="addressTypes.Contact">{{ 'TRANSACTIONS_PAGE.EXISTING_CONTACT' | translate }}</ng-container>
+            </ion-label>
             <ion-input type="text"
                        formControlName="recipientName"
                        name="recipientName"
+                       [disabled]="addressType === addressTypes.Contact || addressType === addressTypes.WalletWithLabel"
                        [(ngModel)]="transaction.recipientName"
                        (keyup)="isRecipientNameAutoSet = false">
             </ion-input>

--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.ts
@@ -32,7 +32,6 @@ import { PinCodeComponent } from '@components/pin-code/pin-code';
 import { ConfirmTransactionComponent } from '@components/confirm-transaction/confirm-transaction';
 import { Clipboard } from '@ionic-native/clipboard';
 import { ToastProvider } from '@providers/toast/toast';
-import { TranslatableObject } from '@models/translate';
 
 @IonicPage()
 @Component({
@@ -259,10 +258,9 @@ export class WalletDashboardPage implements OnInit, OnDestroy {
     const modal = this.modalCtrl.create('SetLabelPage', {'label': this.wallet.label}, {cssClass: 'inset-modal-tiny'});
 
     modal.onDidDismiss((label) => {
-      const isLabelUnique = this.userDataProvider.setWalletLabel(this.wallet, label);
-      if (isLabelUnique === false) {
-        this.toastProvider.error({key: 'WALLETS_PAGE.LABEL_EXISTS', parameters: {label: label}} as TranslatableObject, 3000);
-      }
+      this.userDataProvider
+          .setWalletLabel(this.wallet, label)
+          .subscribe(null, error => this.toastProvider.error(error, 3000));
     });
 
     modal.present();

--- a/src/providers/account-auto-complete/account-auto-complete.ts
+++ b/src/providers/account-auto-complete/account-auto-complete.ts
@@ -5,48 +5,50 @@ import lodash from 'lodash';
 
 import { UserDataProvider } from '@providers/user-data/user-data';
 import { PublicKey } from 'ark-ts/core';
-import {AutoCompleteContact, Contact} from '@models/contact';
+import { AutoCompleteAccount, AutoCompleteAccountType, Contact } from '@models/contact';
 import { Wallet } from '@models/wallet';
 
 @Injectable()
-export class ContactsAutoCompleteService implements AutoCompleteService {
+export class AccountAutoCompleteService implements AutoCompleteService {
 
   // even though this fields are unused, they are required by the AutoCompleteService!
-  public labelAttribute = 'name';
+  public labelAttribute = 'address';
   public formValueAttribute = 'address';
 
   public constructor(private userDataProvider: UserDataProvider) {
   }
 
-  getResults(keyword: string): AutoCompleteContact[] {
+  getResults(keyword: string): AutoCompleteAccount[] {
     keyword = keyword.toLowerCase();
 
-    const contacts: AutoCompleteContact[] = lodash.map(this.userDataProvider.currentProfile.contacts, (contact: Contact) => {
+    const contacts: AutoCompleteAccount[] = lodash.map(this.userDataProvider.currentProfile.contacts, (contact: Contact) => {
       return {
         address: contact.address,
         name: contact.name,
-        iconName: 'ios-contacts-outline'
-      } as AutoCompleteContact;
+        iconName: 'ios-contacts-outline',
+        type: AutoCompleteAccountType.Contact
+      } as AutoCompleteAccount;
     });
 
-    const wallets: AutoCompleteContact[] = lodash.map(this.userDataProvider.currentProfile.wallets, (wallet: Wallet) => {
+    const wallets: AutoCompleteAccount[] = lodash.map(this.userDataProvider.currentProfile.wallets, (wallet: Wallet) => {
       const address = wallet.address;
       const label = this.userDataProvider.getWalletLabel(wallet) || wallet.address;
       if (address) {
         return {
           address: address,
           name: label,
-          iconName: 'ios-cash-outline'
-        } as AutoCompleteContact;
+          iconName: 'ios-cash-outline',
+          type: AutoCompleteAccountType.Wallet
+        } as AutoCompleteAccount;
       }
     });
 
-    return contacts.sort(ContactsAutoCompleteService.sortContacts)
-                   .concat(wallets.sort(ContactsAutoCompleteService.sortContacts))
+    return contacts.sort(AccountAutoCompleteService.sortContacts)
+                   .concat(wallets.sort(AccountAutoCompleteService.sortContacts))
                    .filter(c => this.isValidContact(c, keyword));
   }
 
-  private static sortContacts(a: AutoCompleteContact, b: AutoCompleteContact): number {
+  private static sortContacts(a: AutoCompleteAccount, b: AutoCompleteAccount): number {
     if (a.name !== a.address && b.name === b.address) {
       return -1;
     }
@@ -58,7 +60,7 @@ export class ContactsAutoCompleteService implements AutoCompleteService {
     return a.name.localeCompare(b.name);
   }
 
-  private isValidContact(contact: AutoCompleteContact, keyword: string): boolean {
+  private isValidContact(contact: AutoCompleteAccount, keyword: string): boolean {
     return PublicKey.validateAddress(contact.address, this.userDataProvider.currentNetwork)
            && (contact.address.toLowerCase().indexOf(keyword) > -1
                || (contact.name && contact.name.toLowerCase().indexOf(keyword) > -1));

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -15,6 +15,7 @@ import { Network, NetworkType } from 'ark-ts/model';
 
 import * as constants from '@app/app.constants';
 import { Delegate } from 'ark-ts';
+import { TranslatableObject } from '@models/translate';
 
 @Injectable()
 export class UserDataProvider {
@@ -207,20 +208,21 @@ export class UserDataProvider {
     return this.saveProfiles();
   }
 
-  public setWalletLabel(wallet: Wallet, label: string): boolean {
-    if (!wallet || wallet.label === label) {
-      return;
+  public setWalletLabel(wallet: Wallet, label: string): Observable<any> {
+    if (!wallet) {
+      return Observable.throw({key: 'VALIDATION.INVALID_WALLET'} as TranslatableObject);
     }
 
-    const exists = lodash.some(this.currentProfile.wallets, w => label && w.label && w.label.toLowerCase() === label.toLowerCase());
+    if (wallet.label === label) {
+      return Observable.empty();
+    }
 
-    if (exists) {
-      return false;
+    if (lodash.some(this.currentProfile.wallets, w => label && w.label && w.label.toLowerCase() === label.toLowerCase())) {
+      return Observable.throw({key: 'VALIDATION.LABEL_EXISTS', parameters: {label: label}} as TranslatableObject);
     }
 
     wallet.label = label;
-    this.saveWallet(wallet);
-    return true;
+    return this.saveWallet(wallet);
   }
 
   public getWalletLabel(walletOrAddress: Wallet | string): string {


### PR DESCRIPTION
I found it very annoying that in the "address" field sometimes you only had the address and sometimes only the contact / wallet label.
Plus it wasn't nice that the field jumped around so much (hidden / displayed).
Also you could create a new contact for a wallet instead of just setting a label.

I changed it so it's more consistent for the user and also should be more readable & understandable in code.

Basically there are now 5 possible states in the ui concerning this field:

1. Initial (no address)
![init](https://user-images.githubusercontent.com/1086065/37566018-a702ee9a-2ab3-11e8-9ac3-b5e45b52afe6.png)

2. Existing Contact
![existing_contact](https://user-images.githubusercontent.com/1086065/37566020-ae67bc38-2ab3-11e8-9085-2c6c8220dcaf.PNG)

3. Wallet with label
![existing_wallet](https://user-images.githubusercontent.com/1086065/37566021-b2588f5c-2ab3-11e8-9b0b-dc73e2d89eae.PNG)

4. Wallet without label
![wallet_no_label](https://user-images.githubusercontent.com/1086065/37566022-b64c2948-2ab3-11e8-9b59-ae3169e9a520.PNG)

5. Unknown (new) address
![unknown_contact](https://user-images.githubusercontent.com/1086065/37566025-b883a056-2ab3-11e8-8539-e195e4f87bc6.PNG)


I made the field disabled for existing contacts & labels.

Todo:

-  [x]  wait until #115 is merged back and use method from there to set label