### PR TITLE
Dev net: add notice message on passphrase word tester to inform that words are automatically filled

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -99,7 +99,8 @@
   "NO": "No",
   "PASSPHRASE_TEST": {
     "INFO": "Please type the required words from your passphrase to validate the wallet creation.",
-    "WRONG_WORD": "The typed word is not correct"
+    "WRONG_WORD": "The typed word is not correct",
+    "DEVNET_WORDS_NOTICE": "The words are automatically filled in dev net."
   },
   "PIN_CODE": {
     "CONFIRM": "Confirm your PIN",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -100,7 +100,7 @@
   "PASSPHRASE_TEST": {
     "INFO": "Please type the required words from your passphrase to validate the wallet creation.",
     "WRONG_WORD": "The typed word is not correct",
-    "DEVNET_WORDS_NOTICE": "The words are automatically filled in dev net."
+    "DEVNET_WORDS_NOTICE": "The words are automatically filled in for Devnet"
   },
   "PIN_CODE": {
     "CONFIRM": "Confirm your PIN",

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.html
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.html
@@ -17,6 +17,9 @@
     <ion-row>
       <ion-col text-center>
         <p class="sole-message">{{ 'PASSPHRASE_TEST.INFO' | translate }}</p>
+        <div *ngIf="isDevNet" class="note-message-default">
+          <p>{{ 'PASSPHRASE_TEST.DEVNET_WORDS_NOTICE' | translate }}</p>
+        </div>
       </ion-col>
     </ion-row>
     <ion-row class="account-container">

--- a/src/modals/passphrase-word-tester/passphrase-word-tester.ts
+++ b/src/modals/passphrase-word-tester/passphrase-word-tester.ts
@@ -1,6 +1,7 @@
 import {Component} from '@angular/core';
 import {IonicPage, NavController, NavParams, ViewController} from 'ionic-angular';
 import {PassphraseWord} from '@models/passphrase-word';
+import { UserDataProvider } from '@providers/user-data/user-data';
 
 @IonicPage()
 @Component({
@@ -10,15 +11,19 @@ import {PassphraseWord} from '@models/passphrase-word';
 export class PassphraseWordTesterModal {
 
   public words: PassphraseWord[] = [];
+  public isDevNet: boolean;
 
   public constructor(public navCtrl: NavController,
               public navParams: NavParams,
-              private viewCtrl: ViewController) {
+              private viewCtrl: ViewController,
+              private userDataProvider: UserDataProvider) {
     this.words = this.navParams.get('words') as PassphraseWord[];
 
     if (!this.words) {
       this.dismiss();
     }
+
+    this.isDevNet = this.userDataProvider.isDevNet;
   }
 
   public areAllWordsCorrect(): boolean {


### PR DESCRIPTION
On dev net, when we generate a new wallet and go on the passphrase "word tester" screen to confirm our passphrase, the words are already filled, which is normal.
Just adding here a message to inform that on dev net it's the intended behaviour. (see #116 )