### PR TITLE
Wallet label display fixes

### DIFF
--- a/src/pages/wallet/wallet-dashboard/wallet-dashboard.html
+++ b/src/pages/wallet/wallet-dashboard/wallet-dashboard.html
@@ -4,7 +4,7 @@
     <button ion-button icon-only menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>
-    <ion-title>{{ wallet?.address | accountLabel: 'WALLETS_PAGE.MY_WALLET' | translate }}</ion-title>
+    <ion-title>{{ wallet?.label ? wallet?.label : wallet?.address }}</ion-title>
     <ion-buttons end>
       <button ion-button icon-only (click)="presentWalletActionSheet()">
         <ion-icon name="md-more"></ion-icon>

--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -32,7 +32,7 @@
             <ion-item class="wallet">
               <ion-label [ngClass]="{delegate: wallet?.isDelegate, normal: !wallet?.isDelegate}">
                 <h2 class="amount">{{ currentNetwork?.symbol }} {{ wallet?.balance | unitsSatoshi }}</h2>
-                <p class="address">{{ wallet?.address | accountLabel | truncateMiddle: 15 }}</p>
+                <p class="address">{{ wallet?.label ? wallet?.label : wallet?.address | truncateMiddle: 15 }}</p>
                 <ion-badge class="watch-only-badge" [color]="wallet?.isDelegate ? 'primary' : 'danger-alternative'" *ngIf="wallet.isWatchOnly">
                   {{ 'WATCH_ONLY' | translate }}
                 </ion-badge>


### PR DESCRIPTION
Fix the following issues regarding wallet label display : 

1. When we set / update a label on a wallet, it does not update directly the label in the page title (we have to go back to the wallet list to see that it was updated).

2. If we register a contact with the same address as an existing wallet, then the contact name overrides the wallet label or address in the wallet list and detail.