### PR TITLE
Keep label when converting watch-only wallet to full wallet

### DIFF
--- a/src/pages/wallet/wallet-import/wallet-import.base.ts
+++ b/src/pages/wallet/wallet-import/wallet-import.base.ts
@@ -61,6 +61,12 @@ export abstract class BaseWalletImport {
         if (!privateKey) {
           this.addWallet(newWallet);
         } else {
+          // if we are converting watch-only to full wallet, keep label from existing watch-only wallet
+          const existingWallet = this.userDataProvider.getWalletByAddress(address);
+          if (existingWallet && existingWallet.label) {
+            newWallet.label = existingWallet.label;
+          }
+
           this.verifyWithPinCode(newWallet, passphrase);
         }
       })

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -198,12 +198,6 @@ export class UserDataProvider {
 
     const profile = this.getProfileById(profileId);
     wallet.lastUpdate = new Date().getTime();
-
-    const existingWallet = profile.wallets[wallet.address];
-    if (existingWallet && existingWallet.label) {
-      wallet.label = existingWallet.label;
-    }
-
     profile.wallets[wallet.address] = wallet;
 
     this.profiles[profileId] = profile;

--- a/src/providers/user-data/user-data.ts
+++ b/src/providers/user-data/user-data.ts
@@ -198,6 +198,12 @@ export class UserDataProvider {
 
     const profile = this.getProfileById(profileId);
     wallet.lastUpdate = new Date().getTime();
+
+    const existingWallet = profile.wallets[wallet.address];
+    if (existingWallet && existingWallet.label) {
+      wallet.label = existingWallet.label;
+    }
+
     profile.wallets[wallet.address] = wallet;
 
     this.profiles[profileId] = profile;


### PR DESCRIPTION
When we convert watch-only wallet to full wallet, we loose the label we put on the watch-only wallet.
This allows to keep the label.