### PR TITLE
Fix issue that if you don't allow the camera the app hangs

### DIFF
--- a/src/modals/qr-scanner/qr-scanner.ts
+++ b/src/modals/qr-scanner/qr-scanner.ts
@@ -80,9 +80,9 @@ export class QRScannerModal {
       if (status.showing) {
         this.hideCamera();
       }
+      this.ionApp.classList.remove('transparent');
     });
 
-    this.ionApp.classList.remove('transparent');
     this.viewCtrl.dismiss(qrCode);
   }
 


### PR DESCRIPTION
When you try to import a wallet in iOS, if by mistake (or will) you deny the use of the camera, a black box hangs on the screen and can't be removed.

Even if you close the app and reopen it, the box with stay there and you can't use the wallet.