### PR TITLE
updates readme to ensure devs install the right version of cordova

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ARK’s mobile wallet is a hybrid application (using the same codebase for Andro
 First follow the steps below to install the dependencies:
 
 ```bash
-$ npm install -g ionic cordova
+$ npm install -g ionic cordova@7.1.0
 $ npm install
 $ ionic cordova prepare
 ```


### PR DESCRIPTION
globally since 8.0.0 came out 2 days ago, there are broken plugins still which break the app otherwise.

npm install -g cordova@7.1.0