### PR TITLE
Add info that 24h price is for btc

### DIFF
--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -50,23 +50,17 @@
           <ion-row nowrap justify-content-center align-items-baseline>
             <ion-col text-left *ngIf="fiatCurrency?.code !== 'btc'">
               <p>{{ fiatCurrency?.code | uppercase }} <span class="fiat-bullet"></span></p>
-            </ion-col>
-            <ion-col text-left>
-              <p>{{ btcCurrency?.code | uppercase }} <span class="btc-bullet"></span></p>
-            </ion-col>
-            <ion-col text-left>
-              <p>{{ 'MARKETS_PAGE.PERCENTAGE_CHANGE' | translate }} ({{ currentNetwork?.token }} - {{ btcCurrency?.code | uppercase }})</p>
-            </ion-col>
-          </ion-row>
-          <ion-row nowrap justify-content-center align-items-baseline>
-            <ion-col text-left *ngIf="fiatCurrency?.code !== 'btc'">
               <h6>{{ fiatCurrency?.symbol }}{{ fiatCurrency?.price | marketNumber }}</h6>
             </ion-col>
             <ion-col text-left>
-              <h6>{{ btcCurrency?.price | marketNumber: btcCurrency }}</h6>
-            </ion-col>
-            <ion-col text-left>
-              <h6 ion-text [color]="btcCurrency?.change24h < 0 ? 'danger' : 'secondary'">{{ btcCurrency?.change24h | number: '1.2-2' }}%</h6>
+              <p>
+                {{ btcCurrency?.code | uppercase }} ({{ 'MARKETS_PAGE.PERCENTAGE_CHANGE' | translate }})
+                <span class="btc-bullet"></span>
+              </p>
+              <h6>
+                {{ btcCurrency?.price | marketNumber: btcCurrency }}
+                (<span ion-text [color]="btcCurrency?.change24h < 0 ? 'danger' : 'secondary'">{{ btcCurrency?.change24h | number: '1.2-2' }}%</span>)
+              </h6>
             </ion-col>
           </ion-row>
         </ion-grid>

--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -47,12 +47,12 @@
         <hr>
         <h4 class="market-cap-title"><ion-icon name="md-trending-up"></ion-icon> {{ 'MARKETS_PAGE.MARKET_DATA' | translate }}</h4>
         <ion-grid class="no-padding" class="price-container">
-          <ion-row nowrap justify-content-center align-items-baseline>
-            <ion-col text-left *ngIf="fiatCurrency?.code !== 'btc'">
+          <ion-row nowrap align-items-baseline>
+            <ion-col col-auto *ngIf="fiatCurrency?.code !== 'btc'" style="padding-right: 20px">
               <p>{{ fiatCurrency?.code | uppercase }} <span class="fiat-bullet"></span></p>
               <h6>{{ fiatCurrency?.symbol }}{{ fiatCurrency?.price | marketNumber }}</h6>
             </ion-col>
-            <ion-col text-left>
+            <ion-col col-auto>
               <p>
                 {{ btcCurrency?.code | uppercase }} ({{ 'MARKETS_PAGE.PERCENTAGE_CHANGE' | translate }})
                 <span class="btc-bullet"></span>

--- a/src/pages/wallet/wallet-list/wallet-list.html
+++ b/src/pages/wallet/wallet-list/wallet-list.html
@@ -50,15 +50,23 @@
           <ion-row nowrap justify-content-center align-items-baseline>
             <ion-col text-left *ngIf="fiatCurrency?.code !== 'btc'">
               <p>{{ fiatCurrency?.code | uppercase }} <span class="fiat-bullet"></span></p>
-              <h6>{{ fiatCurrency?.symbol }}{{ fiatCurrency?.price | marketNumber }}</h6>
             </ion-col>
             <ion-col text-left>
               <p>{{ btcCurrency?.code | uppercase }} <span class="btc-bullet"></span></p>
+            </ion-col>
+            <ion-col text-left>
+              <p>{{ 'MARKETS_PAGE.PERCENTAGE_CHANGE' | translate }} ({{ currentNetwork?.token }} - {{ btcCurrency?.code | uppercase }})</p>
+            </ion-col>
+          </ion-row>
+          <ion-row nowrap justify-content-center align-items-baseline>
+            <ion-col text-left *ngIf="fiatCurrency?.code !== 'btc'">
+              <h6>{{ fiatCurrency?.symbol }}{{ fiatCurrency?.price | marketNumber }}</h6>
+            </ion-col>
+            <ion-col text-left>
               <h6>{{ btcCurrency?.price | marketNumber: btcCurrency }}</h6>
             </ion-col>
             <ion-col text-left>
-              <p>{{ 'MARKETS_PAGE.PERCENTAGE_CHANGE' | translate }}</p>
-              <h6 ion-text [color]="fiatCurrency?.change24h < 0 ? 'danger' : 'secondary'">{{ fiatCurrency?.change24h | number: '1.2-2' }}%</h6>
+              <h6 ion-text [color]="btcCurrency?.change24h < 0 ? 'danger' : 'secondary'">{{ btcCurrency?.change24h | number: '1.2-2' }}%</h6>
             </ion-col>
           </ion-row>
         </ion-grid>


### PR DESCRIPTION
This PR is basically a (partial) fix / clarification for #103.
The idea is that the 24h change is ONLY for BTC, because only there we can be sure we have the correct data. If we would want to display the change for the fiat currency, we need to call another API or fix it differently, see the other /  closed PR for that.

This is how it looks now:
![image](https://user-images.githubusercontent.com/1086065/38045809-31450eaa-32be-11e8-90fd-819c1984aaa0.png)
