### PR TITLE
Passphrase bip39 word suggestions

### DIFF
--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
@@ -22,7 +22,7 @@
       <ion-toggle name="nonBIP39Passphrase" [(ngModel)]="nonBIP39Passphrase"></ion-toggle>
     </ion-item>
   </form>
-  <img class="hide-on-keyboard-open" src="./assets/img/light/wallet/import-wallet.png" class="image">
+  <img class="hide-on-keyboard-open image" src="./assets/img/light/wallet/import-wallet.png">
 </ion-content>
 
 <ion-footer no-shadow no-border padding text-center [keyboard-attach]="content">

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
@@ -7,34 +7,22 @@
 </ion-header>
 
 <ion-content class="column-mode" padding #content>
-  <ion-grid>
-    <ion-row>
-      <ion-col text-center>
-        <form #importWalletManual="ngForm">
-          <ion-item>
-            <ion-label floating>
-              {{ (useAddress ? 'WALLETS_PAGE.ENTER_ADDRESS' : 'WALLETS_PAGE.ENTER_SECRET_PASSPHRASE') | translate }}
-            </ion-label>
-            <ion-textarea #inputAddressOrPassphrase (blur)="addressOrPassphraseBlur($event)" name="addressOrPassphrase" rows="2" [ngModel]="addressOrPassphrase" (ngModelChange)="addressOrPassphraseChange($event)" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></ion-textarea>
-          </ion-item>
-          <ion-item *ngIf="wordSuggestions.length > 0" no-padding no-lines>
-            <button (click)="suggestionClick(0)" *ngIf="wordSuggestions[0]" ion-button color="light" round small name="wordSuggestion0">{{ wordSuggestions[0] }}</button>
-            <button (click)="suggestionClick(1)" *ngIf="wordSuggestions[1]" ion-button color="light" round small name="wordSuggestion1">{{ wordSuggestions[1] }}</button>
-            <button (click)="suggestionClick(2)" *ngIf="wordSuggestions[2]" ion-button color="light" round small name="wordSuggestion2">{{ wordSuggestions[2] }}</button>
-          </ion-item>
-          <ion-item *ngIf="!useAddress" no-padding no-lines style="background-color:transparent">
-          <ion-label>Custom (non <a (click)="openBIP39DocURL()">BIP39</a>) passphrase</ion-label>
-          <ion-toggle name="nonBIP39Passphrase" [(ngModel)]="nonBIP39Passphrase"></ion-toggle>
-        </ion-item>
-        </form>
-      </ion-col>
-    </ion-row>
-    <ion-row class="hide-on-keyboard-open">
-      <ion-col text-center>
-        <img src="./assets/img/light/wallet/import-wallet.png" class="image">
-      </ion-col>
-    </ion-row>
-  </ion-grid>
+  <form #importWalletManual="ngForm">
+    <ion-item>
+      <ion-label floating>
+        {{ (useAddress ? 'WALLETS_PAGE.ENTER_ADDRESS' : 'WALLETS_PAGE.ENTER_SECRET_PASSPHRASE') | translate }}
+      </ion-label>
+      <ion-textarea #inputAddressOrPassphrase name="addressOrPassphrase" rows="2" [ngModel]="addressOrPassphrase" (ngModelChange)="addressOrPassphraseChange($event)" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></ion-textarea>
+    </ion-item>
+    <button (click)="suggestionClick(0)" *ngIf="wordSuggestions[0]" ion-button color="light" round small name="wordSuggestion0">{{ wordSuggestions[0] }}</button>
+    <button (click)="suggestionClick(1)" *ngIf="wordSuggestions[1]" ion-button color="light" round small name="wordSuggestion1">{{ wordSuggestions[1] }}</button>
+    <button (click)="suggestionClick(2)" *ngIf="wordSuggestions[2]" ion-button color="light" round small name="wordSuggestion2">{{ wordSuggestions[2] }}</button>
+    <ion-item *ngIf="!useAddress" no-padding no-lines style="background-color:transparent">
+      <ion-label>Custom (non <a (click)="openBIP39DocURL()">BIP39</a>) passphrase</ion-label>
+      <ion-toggle name="nonBIP39Passphrase" [(ngModel)]="nonBIP39Passphrase"></ion-toggle>
+    </ion-item>
+  </form>
+  <img class="hide-on-keyboard-open" src="./assets/img/light/wallet/import-wallet.png" class="image">
 </ion-content>
 
 <ion-footer no-shadow no-border padding text-center [keyboard-attach]="content">

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
@@ -17,6 +17,11 @@
             </ion-label>
             <ion-textarea #inputAddressOrPassphrase (blur)="addressOrPassphraseBlur($event)" name="addressOrPassphrase" rows="2" [ngModel]="addressOrPassphrase" (ngModelChange)="addressOrPassphraseChange($event)" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></ion-textarea>
           </ion-item>
+          <ion-item *ngIf="wordSuggestions.length > 0" no-padding no-lines>
+            <button (click)="suggestionClick(0)" *ngIf="wordSuggestions[0]" ion-button color="light" round small name="wordSuggestion0">{{ wordSuggestions[0] }}</button>
+            <button (click)="suggestionClick(1)" *ngIf="wordSuggestions[1]" ion-button color="light" round small name="wordSuggestion1">{{ wordSuggestions[1] }}</button>
+            <button (click)="suggestionClick(2)" *ngIf="wordSuggestions[2]" ion-button color="light" round small name="wordSuggestion2">{{ wordSuggestions[2] }}</button>
+          </ion-item>
           <ion-item *ngIf="!useAddress" no-padding no-lines style="background-color:transparent">
           <ion-label>Custom (non <a (click)="openBIP39DocURL()">BIP39</a>) passphrase</ion-label>
           <ion-toggle name="nonBIP39Passphrase" [(ngModel)]="nonBIP39Passphrase"></ion-toggle>
@@ -33,8 +38,5 @@
 </ion-content>
 
 <ion-footer no-shadow no-border padding text-center [keyboard-attach]="content">
-  <button *ngIf="wordSuggestions[0]" ion-button color="light" round small name="wordSuggestion0">{{ wordSuggestions[0] }}</button>
-  <button *ngIf="wordSuggestions[1]" ion-button color="light" round small name="wordSuggestion1">{{ wordSuggestions[1] }}</button>
-  <button *ngIf="wordSuggestions[2]" ion-button color="light" round small name="wordSuggestion2">{{ wordSuggestions[2] }}</button>
   <button ion-button class="button-continue" [disabled]="!importWalletManual.form.valid" (click)="submitForm()">{{ 'IMPORT' | translate }}</button>
 </ion-footer>

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
@@ -15,7 +15,7 @@
             <ion-label floating>
               {{ (useAddress ? 'WALLETS_PAGE.ENTER_ADDRESS' : 'WALLETS_PAGE.ENTER_SECRET_PASSPHRASE') | translate }}
             </ion-label>
-            <ion-textarea name="addressOrPassphrase" rows="2" [(ngModel)]="addressOrPassphrase" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></ion-textarea>
+            <ion-textarea #inputAddressOrPassphrase (blur)="addressOrPassphraseBlur($event)" name="addressOrPassphrase" rows="2" [ngModel]="addressOrPassphrase" (ngModelChange)="addressOrPassphraseChange($event)" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></ion-textarea>
           </ion-item>
           <ion-item *ngIf="!useAddress" no-padding no-lines style="background-color:transparent">
           <ion-label>Custom (non <a (click)="openBIP39DocURL()">BIP39</a>) passphrase</ion-label>
@@ -33,5 +33,8 @@
 </ion-content>
 
 <ion-footer no-shadow no-border padding text-center [keyboard-attach]="content">
+  <button *ngIf="wordSuggestions[0]" ion-button color="light" round small name="wordSuggestion0">{{ wordSuggestions[0] }}</button>
+  <button *ngIf="wordSuggestions[1]" ion-button color="light" round small name="wordSuggestion1">{{ wordSuggestions[1] }}</button>
+  <button *ngIf="wordSuggestions[2]" ion-button color="light" round small name="wordSuggestion2">{{ wordSuggestions[2] }}</button>
   <button ion-button class="button-continue" [disabled]="!importWalletManual.form.valid" (click)="submitForm()">{{ 'IMPORT' | translate }}</button>
 </ion-footer>

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
@@ -79,14 +79,7 @@ export class WalletManualImportPage extends BaseWalletImport  {
     }
   }
 
-  addressOrPassphraseBlur(event) {
-    if (!event.relatedTarget) { return; }
-    const relatedName = event.relatedTarget.name;
-    if (!relatedName || relatedName.indexOf('wordSuggestion') === -1) { return; }
-
-    const index = parseInt(relatedName[relatedName.length - 1]); // 0,1 or 2 from wordSuggestion0,1,2
-    if (isNaN(index)) { return; }
-
+  suggestionClick(index) {
     const wordsPassphrase = this.addressOrPassphrase.split(' ');
     wordsPassphrase[wordsPassphrase.length - 1] = this.wordSuggestions[index];
     this.addressOrPassphrase = wordsPassphrase.join(' ');

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { IonicPage, NavController, NavParams, ModalController } from 'ionic-angular';
 import { InAppBrowser } from '@ionic-native/in-app-browser';
 
@@ -22,6 +22,8 @@ export class WalletManualImportPage extends BaseWalletImport  {
   public addressOrPassphrase: string;
   public useAddress: boolean;
   public nonBIP39Passphrase: boolean;
+  public wordSuggestions = [];
+  @ViewChild('inputAddressOrPassphrase') inputAddressOrPassphrase;
 
   constructor(
     navParams: NavParams,
@@ -45,5 +47,51 @@ export class WalletManualImportPage extends BaseWalletImport  {
 
   openBIP39DocURL() {
     return this.inAppBrowser.create(constants.BIP39_DOCUMENTATION_URL, '_system');
+  }
+
+  addressOrPassphraseChange(value) {
+    const lastAddressOrPassphrase = this.addressOrPassphrase || '';
+    this.addressOrPassphrase = value;
+
+    this.suggestWord(lastAddressOrPassphrase, this.addressOrPassphrase);
+  }
+
+  suggestWord(lastPassphrase, passphrase) {
+    this.wordSuggestions = [];
+
+    if (this.useAddress || this.nonBIP39Passphrase) { return; }
+
+    const wordsLastPassphrase = lastPassphrase.split(' ');
+    const wordsPassphrase = passphrase.split(' ');
+    if (wordsLastPassphrase.length !== wordsPassphrase.length) { return; }
+    // don't do anything if we type 1st letter of a new word or if we remove one word
+
+    const lastWordLastPassphrase = wordsLastPassphrase.pop();
+    const lastWordPassphrase = wordsPassphrase.pop();
+    if (wordsLastPassphrase.join() !== wordsPassphrase.join()) { return; } // we only want the last word to change
+
+    if (Math.abs(lastWordLastPassphrase.length - lastWordPassphrase.length) === 1 && lastWordPassphrase.length > 1 &&
+        (lastWordLastPassphrase.indexOf(lastWordPassphrase) !== -1 || lastWordPassphrase.indexOf(lastWordLastPassphrase) !== -1 )) {
+      // we just want one letter to be different - only "manual" typing, don't suggest on copy/paste stuff
+      const bip39 = require('bip39');
+      const englishWordlist = bip39.wordlists.english;
+      this.wordSuggestions = englishWordlist.filter( word => word.indexOf(lastWordPassphrase) === 0 );
+    }
+  }
+
+  addressOrPassphraseBlur(event) {
+    if (!event.relatedTarget) { return; }
+    const relatedName = event.relatedTarget.name;
+    if (!relatedName || relatedName.indexOf('wordSuggestion') === -1) { return; }
+
+    const index = parseInt(relatedName[relatedName.length - 1]); // 0,1 or 2 from wordSuggestion0,1,2
+    if (isNaN(index)) { return; }
+
+    const wordsPassphrase = this.addressOrPassphrase.split(' ');
+    wordsPassphrase[wordsPassphrase.length - 1] = this.wordSuggestions[index];
+    this.addressOrPassphrase = wordsPassphrase.join(' ');
+
+    this.wordSuggestions = [];
+    this.inputAddressOrPassphrase.setFocus();
   }
 }


### PR DESCRIPTION
So here is a 1st version for passphrase word suggestion (#126).

- Suggesting only for last word of passphrase, and only when adding or removing one letter (not acting on copy-pasting words, neither if you want to insert or change a word which is inside the passphrase) : for simplicity and avoiding bugs or bad user experience (I did not want to check / play with cursor position)
- Word suggestion starts from 2 letters (type 'a' => no suggestion, type 'ax' => 'axis' suggested)
- Word suggested are shown in the footer above 'import' button, so they are shown above everything even when keyboard is shown
- Only suggesting in English right now (I will improve on this after, and apply this to bip39 validation too)

I went through a lot of pain to keep the textarea input focused when clicking on the suggested words. I finally found that using 'blur' event worked better than trying with button 'click' (and 'mousedown' and 'touchstart' etc).

Looking forward to hear what you think, there are probably things to rework.