### PR TITLE
Feature : Generate and import passphrase in all possible bip39 languages

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -156,7 +156,8 @@
     "NOTIFICATIONS": "Notifications",
     "SETTINGS": "Settings",
     "VERSION": "Version",
-    "WALLET_BACKUP": "Wallet Backup"
+    "WALLET_BACKUP": "Wallet Backup",
+    "WORDLIST_LANGUAGE": "Wordlist language"
   },
   "SHOW_ADVANCED": "Show Advanced",
   "SKIP": "Skip",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -157,7 +157,7 @@
     "SETTINGS": "Settings",
     "VERSION": "Version",
     "WALLET_BACKUP": "Wallet Backup",
-    "WORDLIST_LANGUAGE": "Wordlist language"
+    "WORDLIST_LANGUAGE": "Passphrase language"
   },
   "SHOW_ADVANCED": "Show Advanced",
   "SKIP": "Skip",

--- a/src/modals/wallet-backup/wallet-backup.ts
+++ b/src/modals/wallet-backup/wallet-backup.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import {IonicPage, ModalController, NavController, NavParams, ViewController} from 'ionic-angular';
 
 import { UserDataProvider } from '@providers/user-data/user-data';
+import { SettingsDataProvider } from '@providers/settings-data/settings-data';
 import { PrivateKey } from 'ark-ts/core';
 import bip39 from 'bip39';
 import { WalletKeys, AccountBackup, PassphraseWord } from '@models/model';
@@ -23,13 +24,15 @@ export class WalletBackupModal {
   public account: AccountBackup;
 
   private currentNetwork;
+  private wordlistLanguage: string;
 
   constructor(
     public navCtrl: NavController,
     public navParams: NavParams,
     private viewCtrl: ViewController,
     private modalCtrl: ModalController,
-    private userDataProvider: UserDataProvider) {
+    private userDataProvider: UserDataProvider,
+    private settingsDataProvider: SettingsDataProvider) {
     this.title = this.navParams.get('title');
     this.entropy = this.navParams.get('entropy');
     this.keys = this.navParams.get('keys');
@@ -38,6 +41,7 @@ export class WalletBackupModal {
     if (!this.title || (!this.entropy && !this.keys)) { this.dismiss(); }
 
     this.currentNetwork = this.userDataProvider.currentNetwork;
+    this.settingsDataProvider.settings.subscribe((settings) => this.wordlistLanguage = settings.wordlistLanguage);
   }
 
   next() {
@@ -112,9 +116,10 @@ export class WalletBackupModal {
 
   private generateAccountFromEntropy() {
     const account: AccountBackup = {};
+    const wordlist = bip39.wordlists[this.wordlistLanguage || 'english'];
 
     account.entropy = this.entropy;
-    account.mnemonic = bip39.entropyToMnemonic(account.entropy);
+    account.mnemonic = bip39.entropyToMnemonic(account.entropy, wordlist);
 
     const pvKey = PrivateKey.fromSeed(account.mnemonic, this.currentNetwork);
     const pbKey = pvKey.getPublicKey();

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -2,6 +2,7 @@
 export class UserSettings {
   public language: string;
   public currency: string;
+  public wordlistLanguage: string;
   public darkMode: boolean;
   public notification: boolean;
 
@@ -11,6 +12,7 @@ export class UserSettings {
     const settings = new UserSettings();
     settings.language = lang;
     settings.currency = 'usd';
+    settings.wordlistLanguage = 'english';
     settings.darkMode = false;
     settings.notification = false;
 

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -30,6 +30,15 @@
           </ion-option>
         </ion-select>
       </ion-item>
+      <ion-item>
+        <ion-icon name="ios-book-outline" color="primary" item-start></ion-icon>
+        <ion-label>{{ 'SETTINGS_PAGE.WORDLIST_LANGUAGE' | translate }}</ion-label>
+        <ion-select [(ngModel)]="currentSettings.wordlistLanguage" (ngModelChange)="onUpdate()" cancelText="{{ 'CANCEL' | translate }}">
+          <ion-option *ngFor="let item of objectKeys(availableOptions?.wordlistLanguages)" [value]="item">
+            {{ availableOptions?.wordlistLanguages[item] }}
+          </ion-option>
+        </ion-select>
+      </ion-item>
     </ion-item-group>
 
     <ion-item-group>

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
@@ -7,6 +7,7 @@ import { ArkApiProvider } from '@providers/ark-api/ark-api';
 import { ToastProvider } from '@providers/toast/toast';
 
 import { NetworkProvider } from '@providers/network/network';
+import { SettingsDataProvider } from '@providers/settings-data/settings-data';
 import { BaseWalletImport } from '@root/src/pages/wallet/wallet-import/wallet-import.base';
 
 import * as constants from '@app/app.constants';
@@ -31,8 +32,9 @@ export class WalletManualImportPage extends BaseWalletImport  {
     toastProvider: ToastProvider,
     modalCtrl: ModalController,
     networkProvider: NetworkProvider,
+    settingsDataProvider: SettingsDataProvider,
     private inAppBrowser: InAppBrowser) {
-    super(navParams, navCtrl, userDataProvider, arkApiProvider, toastProvider, modalCtrl, networkProvider);
+    super(navParams, navCtrl, userDataProvider, arkApiProvider, toastProvider, modalCtrl, networkProvider, settingsDataProvider);
     this.useAddress = navParams.get('type') === 'address';
     this.nonBIP39Passphrase = false;
   }

--- a/src/pages/wallet/wallet-import/wallet-import.ts
+++ b/src/pages/wallet/wallet-import/wallet-import.ts
@@ -7,6 +7,7 @@ import { ToastProvider } from '@providers/toast/toast';
 import { QRScannerComponent } from '@components/qr-scanner/qr-scanner';
 import { BaseWalletImport } from '@root/src/pages/wallet/wallet-import/wallet-import.base';
 import { NetworkProvider } from '@providers/network/network';
+import { SettingsDataProvider } from '@providers/settings-data/settings-data';
 
 @IonicPage()
 @Component({
@@ -23,9 +24,10 @@ export class WalletImportPage extends BaseWalletImport {
     arkApiProvider: ArkApiProvider,
     toastProvider: ToastProvider,
     modalCtrl: ModalController,
-    networkProvider: NetworkProvider
+    networkProvider: NetworkProvider,
+    settingsDataProvider: SettingsDataProvider
   ) {
-    super(navParams, navCtrl, userDataProvider, arkApiProvider, toastProvider, modalCtrl, networkProvider);
+    super(navParams, navCtrl, userDataProvider, arkApiProvider, toastProvider, modalCtrl, networkProvider, settingsDataProvider);
   }
 
   openManualImportPage(type: string) {

--- a/src/providers/settings-data/settings-data.ts
+++ b/src/providers/settings-data/settings-data.ts
@@ -52,6 +52,16 @@ export class SettingsDataProvider {
       'mxn': 'Mexican Peso',
       'czk': 'Česká koruna'
     },
+    wordlistLanguages: {
+    'english': 'English',
+    'french': 'French',
+    'spanish': 'Spanish',
+    'italian': 'Italian',
+    'japanese': 'Japanese',
+    'korean': 'Korean',
+    'chinese_simplified': 'Chinese simplified',
+    'chinese_traditional': 'Chinese traditional'
+    }
   };
 
   constructor(private _storageProvider: StorageProvider, private translateService: TranslateService) {


### PR DESCRIPTION
This is a suggestion to allow to generate and import passphrase in any language (from the possible languages defined in bip39 wordlist).

I created a new option "Wordlist language" in Settings : 
![image](https://user-images.githubusercontent.com/36802613/38862179-559de704-4245-11e8-9e96-a2e43e1d84d0.png)
The language selected will be used to generate a new wallet (the passphrase will be in this language), and also for importing a wallet from passphrase (we will be able to enter the passphrase in this language).

For wallet import, entering a passphrase in english will still work, even if we select a different language in "Wordlist language". (we might want to generate wallets in a specific language but import a previous wallet which was generated in english)

Please tell me what do you think 😄 