### PR TITLE
Wallet import form validation on address and passphrase

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -258,6 +258,9 @@
     "GENERATE_ENTROPY": "Generate Entropy",
     "IMPORT_INVALID_ADDRESS": "This address can not be imported into this profile",
     "IMPORT_WALLET": "Import Wallet",
+    "INVALID_12_WORDS_REQUIRED": "12 words required",
+    "INVALID_ADDRESS": "Invalid address",
+    "INVALID_MNEMONIC": "Invalid mnemonic",
     "KEEP_SAFE": "Keep Safe",
     "LABEL": "Label",
     "MY_WALLET": "My Wallet",
@@ -285,6 +288,8 @@
     "SEED": "Seed",
     "TOTAL_BALANCE": "Total Balance",
     "USERNAME": "Username",
+    "VALID_ADDRESS": "Valid address",
+    "VALID_PASSPHRASE": "Valid passphrase",
     "WALLETS": "Wallets",
     "WIF": "WIF"
   },

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.html
@@ -7,19 +7,29 @@
 </ion-header>
 
 <ion-content class="column-mode" padding #content>
-  <form #importWalletManual="ngForm">
+  <form #importWalletManual="ngForm" [formGroup]="manualImportFormGroup">
     <ion-item>
       <ion-label floating>
         {{ (useAddress ? 'WALLETS_PAGE.ENTER_ADDRESS' : 'WALLETS_PAGE.ENTER_SECRET_PASSPHRASE') | translate }}
       </ion-label>
-      <ion-textarea #inputAddressOrPassphrase name="addressOrPassphrase" rows="2" [ngModel]="addressOrPassphrase" (ngModelChange)="addressOrPassphraseChange($event)" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></ion-textarea>
+      <ion-textarea #inputAddressOrPassphrase name="addressOrPassphrase" rows="2" [ngModel]="addressOrPassphrase" (ngModelChange)="addressOrPassphraseChange($event)" formControlName="controlAddressOrPassphrase" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" required></ion-textarea>
     </ion-item>
     <button (click)="suggestionClick(0)" *ngIf="wordSuggestions[0]" ion-button color="light" round small name="wordSuggestion0">{{ wordSuggestions[0] }}</button>
     <button (click)="suggestionClick(1)" *ngIf="wordSuggestions[1]" ion-button color="light" round small name="wordSuggestion1">{{ wordSuggestions[1] }}</button>
     <button (click)="suggestionClick(2)" *ngIf="wordSuggestions[2]" ion-button color="light" round small name="wordSuggestion2">{{ wordSuggestions[2] }}</button>
+    <p *ngIf="manualImportFormGroup.valid && !nonBIP39Passphrase" style="text-align:right">
+      <ion-label color="secondary">{{ (useAddress ? 'WALLETS_PAGE.VALID_ADDRESS' : 'WALLETS_PAGE.VALID_PASSPHRASE') | translate }}</ion-label>
+    </p>
+    <p *ngIf="!manualImportFormGroup.valid && manualImportFormGroup.errors" style="text-align:right">
+      <ion-label *ngIf="manualImportFormGroup.errors.not12Words" color="danger">{{ 'WALLETS_PAGE.INVALID_12_WORDS_REQUIRED' | translate }}</ion-label>
+      <ion-label *ngIf="manualImportFormGroup.errors.invalidMnemonic" color="danger">{{ 'WALLETS_PAGE.INVALID_MNEMONIC' | translate }}</ion-label>
+    </p>
+    <p *ngIf="!manualImportFormGroup.controls.controlAddressOrPassphrase.valid" style="text-align:right">
+      <ion-label *ngIf="manualImportFormGroup.controls.controlAddressOrPassphrase.errors.invalidAddress" color="danger">{{ 'WALLETS_PAGE.INVALID_ADDRESS' | translate }}</ion-label>
+    </p>
     <ion-item *ngIf="!useAddress" no-padding no-lines style="background-color:transparent">
       <ion-label>Custom (non <a (click)="openBIP39DocURL()">BIP39</a>) passphrase</ion-label>
-      <ion-toggle name="nonBIP39Passphrase" [(ngModel)]="nonBIP39Passphrase"></ion-toggle>
+      <ion-toggle name="nonBIP39Passphrase" [(ngModel)]="nonBIP39Passphrase" formControlName="controlNonBIP39"></ion-toggle>
     </ion-item>
   </form>
   <img class="hide-on-keyboard-open image" src="./assets/img/light/wallet/import-wallet.png">

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
@@ -57,7 +57,7 @@ export class WalletManualImportPage extends BaseWalletImport  {
   initFormValidation() {
     const validatorAddressFct = this.useAddress ? this.addressValidator.isValid.bind(this.addressValidator) : null;
     const validatorGroupFct = this.useAddress ? {} : { validator: PassphraseValidator.isValid };
-    // We use form group validator for passphrase validation as we need the 'nonBIP39Passphrase' boolean value with the actual passphrase value
+    // We use form group validator for passphrase validation as we need the 'nonBIP39Passphrase' bool value and the passphrase value
 
     this.manualImportFormGroup = this.formBuilder.group({
       controlAddressOrPassphrase: ['', validatorAddressFct],

--- a/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
+++ b/src/pages/wallet/wallet-import-manual/wallet-import-manual.ts
@@ -9,13 +9,17 @@ import { ToastProvider } from '@providers/toast/toast';
 import { NetworkProvider } from '@providers/network/network';
 import { BaseWalletImport } from '@root/src/pages/wallet/wallet-import/wallet-import.base';
 
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { PassphraseValidator } from '@root/src/validators/passphrase/passphrase';
+import { AddressValidator } from '@root/src/validators/address/address';
+
 import * as constants from '@app/app.constants';
 
 @IonicPage()
 @Component({
   selector: 'page-wallet-import-passphrase',
   templateUrl: 'wallet-import-manual.html',
-  providers: [InAppBrowser]
+  providers: [InAppBrowser, AddressValidator]
 })
 export class WalletManualImportPage extends BaseWalletImport  {
 
@@ -23,6 +27,7 @@ export class WalletManualImportPage extends BaseWalletImport  {
   public useAddress: boolean;
   public nonBIP39Passphrase: boolean;
   public wordSuggestions = [];
+  public manualImportFormGroup: FormGroup;
   @ViewChild('inputAddressOrPassphrase') inputAddressOrPassphrase;
 
   constructor(
@@ -33,16 +38,31 @@ export class WalletManualImportPage extends BaseWalletImport  {
     toastProvider: ToastProvider,
     modalCtrl: ModalController,
     networkProvider: NetworkProvider,
-    private inAppBrowser: InAppBrowser) {
+    private inAppBrowser: InAppBrowser,
+    private formBuilder: FormBuilder,
+    private addressValidator: AddressValidator) {
     super(navParams, navCtrl, userDataProvider, arkApiProvider, toastProvider, modalCtrl, networkProvider);
     this.useAddress = navParams.get('type') === 'address';
     this.nonBIP39Passphrase = false;
+
+    this.initFormValidation();
   }
 
   submitForm() {
     this.import(this.useAddress ? this.addressOrPassphrase : null,
                 this.useAddress ? null : this.addressOrPassphrase,
                 !this.nonBIP39Passphrase);
+  }
+
+  initFormValidation() {
+    const validatorAddressFct = this.useAddress ? this.addressValidator.isValid.bind(this.addressValidator) : null;
+    const validatorGroupFct = this.useAddress ? {} : { validator: PassphraseValidator.isValid };
+    // We use form group validator for passphrase validation as we need the 'nonBIP39Passphrase' boolean value with the actual passphrase value
+
+    this.manualImportFormGroup = this.formBuilder.group({
+      controlAddressOrPassphrase: ['', validatorAddressFct],
+      controlNonBIP39: ['']
+    }, validatorGroupFct);
   }
 
   openBIP39DocURL() {
@@ -59,7 +79,7 @@ export class WalletManualImportPage extends BaseWalletImport  {
   suggestWord(lastPassphrase, passphrase) {
     this.wordSuggestions = [];
 
-    if (this.useAddress || this.nonBIP39Passphrase) { return; }
+    if (this.useAddress || this.nonBIP39Passphrase || !passphrase) { return; }
 
     const wordsLastPassphrase = lastPassphrase.split(' ');
     const wordsPassphrase = passphrase.split(' ');

--- a/src/validators/address/address.ts
+++ b/src/validators/address/address.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { NetworkProvider } from '@providers/network/network';
+
+@Injectable()
+export class AddressValidator {
+
+  public constructor(private networkProvider: NetworkProvider) {}
+
+  public isValid(control: FormControl): any {
+    if (!control.value) { return null; }
+
+    if (!this.networkProvider.isValidAddress(control.value)) {
+      return { 'invalidAddress': true };
+    }
+
+    return null;
+  }
+
+}

--- a/src/validators/passphrase/passphrase.ts
+++ b/src/validators/passphrase/passphrase.ts
@@ -1,0 +1,19 @@
+import { FormGroup } from '@angular/forms';
+import bip39 from 'bip39';
+
+export class PassphraseValidator {
+
+  static isValid(group: FormGroup) {
+      const passphrase = group.controls.controlAddressOrPassphrase.value;
+      const nonBIP39 = group.controls.controlNonBIP39.value;
+
+      if (nonBIP39 || !passphrase) { return null; }
+      const words = passphrase.split(' ');
+      if (words.length !== 12) { return { 'not12Words': true }; }
+
+      if (!bip39.validateMnemonic(passphrase)) { return { 'invalidMnemonic': true }; }
+
+      return null;
+  }
+
+}


### PR DESCRIPTION
Hi, what do you think about adding form validation in wallet import for address and passphrase ? So that the user can see directly if he mistyped something or if there is anything wrong with the input.

I created form validators in a new folder src/validators, tell me if you think it belongs somewhere else.

Looking forward to hear your opinion on this ! Thanks.