### PR TITLE
Manage custom networks: display a different message when no network has been configured

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -44,6 +44,7 @@
     "NETHASH": "Nethash",
     "MANAGE_NETWORKS": "Manage Custom Networks",
     "MARKET_SYMBOL_NAME": "Market Symbol Name (for getting prices in USD, BTC, etc.)",
+    "NO_NETWORK_CONFIGURED": "No custom network has been configured yet. Click on the button below to create one.",
     "OR_CREATE_NEW": "... or create a new custom network",
     "SAVE_SUCCESSFUL": "Successfully saved network!",
     "SEED_SERVER": "Seed Server URL",

--- a/src/components/custom-network/custom-network.html
+++ b/src/components/custom-network/custom-network.html
@@ -1,12 +1,12 @@
 <ion-grid fixed>
-  <ion-row text-wrap>
+  <ion-row text-wrap *ngIf="networkChoices && networkChoices.length > 0">
     <ion-col >
       <ion-item>
         {{ 'CUSTOM_NETWORK.CHOOSE_EXISTING' | translate}}
       </ion-item>
     </ion-col>
   </ion-row>
-  <ion-row>
+  <ion-row *ngIf="networkChoices && networkChoices.length > 0">
     <ion-col >
       <ion-item>
         <ion-label>{{ 'CUSTOM_NETWORK.CUSTOM_NETWORK' | translate}}</ion-label>
@@ -16,10 +16,17 @@
       </ion-item>
     </ion-col>
   </ion-row>
-  <ion-row text-wrap>
+  <ion-row text-wrap *ngIf="networkChoices && networkChoices.length > 0">
     <ion-col>
       <ion-item>
         {{ 'CUSTOM_NETWORK.OR_CREATE_NEW' | translate}}
+      </ion-item>
+    </ion-col>
+  </ion-row>
+  <ion-row text-wrap *ngIf="!networkChoices || networkChoices.length == 0">
+    <ion-col>
+      <ion-item>
+        {{ 'CUSTOM_NETWORK.NO_NETWORK_CONFIGURED' | translate}}
       </ion-item>
     </ion-col>
   </ion-row>


### PR DESCRIPTION
When there is no custom network configured yet, instead of displaying the "classic" UI with messages "Either choose an existing custom network... or create a new custom network",
just display the message "No custom network has been configured yet. Click on the button below to create one."